### PR TITLE
Adding 0xADB0 pid for ADB/USB

### DIFF
--- a/1209/ADB0/index.md
+++ b/1209/ADB0/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: ADB/USB converter
+owner: tibounise
+license: BSD 3-clause
+site: http://tibounise.com/adbusb.html
+source: https://github.com/tibounise/ADBUSB-0x1
+---

--- a/org/tibounise/index.md
+++ b/org/tibounise/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: tibounise
+---
+
+TiBounise is my username, I'm like to do things like hardware reverse engineering. I'm currently selling ADB to USB converters. My website is http://tibounise.com.


### PR DESCRIPTION
I'm selling a device called [ADB/USB](http://tibounise.com/adbusb.html). It is using the open source firmware [tmk_keyboard](https://github.com/tmk/tmk_keyboard), and the firmware is under BSD licence ([EagleCAD schematics available here](https://github.com/tibounise/ADBUSB-0x1)).

I would really like to have a custom PID for my adapter. Feel free to contact me if you need more informations ! :smile: 