### PR TITLE
Keyboardio Model 01 & Keyboardio Model 01 Bootloader

### DIFF
--- a/1209/2300/index.md
+++ b/1209/2300/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Keyboardio Model 01 Bootloader
+owner: keyboardio
+license: GPLv2
+site: http://keyboard.io
+source: https://github.com/obra/KeyboardioFirmware/
+---

--- a/1209/2301/index.md
+++ b/1209/2301/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Keyboardio Model 01
+owner: keyboardio
+license: GPLv2
+site: http://keyboard.io
+source: https://github.com/obra/KeyboardioFirmware/
+---

--- a/org/keyboardio/index.md
+++ b/org/keyboardio/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Keyboardio
+---
+Keyboardio makes computer keyboards that come with source code and a screwdriver.


### PR DESCRIPTION
Requesting a pair of PIDs for the Keyboardio Model 01 hackable ergonomic keyboard. As is customary, we'd like to use separate PIDs for the bootloader and user runtime. (They're separate codebases with separate USB profiles. They do run on the same hardware.)

Thanks so much!