### PR TITLE
"OpenVSM Virtual USB HID" PID request

### DIFF
--- a/1209/C0DE/index.md
+++ b/1209/C0DE/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: OpenVSM Virtual USB
-owner: NonameGarage
+owner: Nonamegarage
 license: BSD
 site: https://github.com/Pugnator/openvsm
 source: https://github.com/Pugnator/openvsm/tree/testing

--- a/1209/C0DE/index.md
+++ b/1209/C0DE/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: OpenVSM Virtual USB
+owner: NonameGarage
+license: BSD
+site: https://github.com/Pugnator/openvsm
+source: https://github.com/Pugnator/openvsm/tree/testing
+---

--- a/org/nonamegarage/index.md
+++ b/org/nonamegarage/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Nonamegarage
+---
+Nonamegarage is a group of people creating devices and software
+for amateur autosport. And all that software is opensource.
+


### PR DESCRIPTION
This PID is need for Virtual USB device. 
It will be used during simulation under Proteus for interracting with user's real hardware.