### PR TITLE
Fix mistake with KnightOS PIDs

### DIFF
--- a/1209/CA1C/index.md
+++ b/1209/CA1C/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: KnightOS Generic Hub
+title: Generic Hub
 owner: knightos
 license: MIT
 site: http://www.knightos.org/

--- a/1209/CA1D/index.md
+++ b/1209/CA1D/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: KnightOS MTP Device
+title: MTP Device
 owner: knightos
 license: MIT
 site: http://www.knightos.org/


### PR DESCRIPTION
Prevents this from happening:

![2015-04-05_10 28 48](https://cloud.githubusercontent.com/assets/1310872/6997609/040fe46c-db7f-11e4-999d-9d05558f45a4.png)
