### PR TITLE
Refflion - Arduino compatible IoT development Board

### DIFF
--- a/1209/7530/index.md
+++ b/1209/7530/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pid
-title: Refflion: IoT Development Board - Bootloader
-owner: PotentialLabs
-license: TAPR Open Hardware License
-site: http://refflion.io/
-source: https://bitbucket.org/PotentialLabs/refflion/
+title: My device name
+owner: myorg
+license: MIT
+site: http://www.mysite.com/
+source: http://github.com/myorg/mydevice/
 ---
-Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform. This board uses the low cost ESP8266 WiFi Module for Wireless connectivity.

--- a/1209/7530/index.md
+++ b/1209/7530/index.md
@@ -1,8 +1,8 @@
 ---
 layout: pid
-title: My device name
-owner: myorg
-license: MIT
-site: http://www.mysite.com/
-source: http://github.com/myorg/mydevice/
+title: Refflion - IoT Development Board - Bootloader
+owner: PotentialLabs
+license: TAPR Open Hardware License
+site: http://refflion.io
+source: https://bitbucket.org/PotentialLabs/refflion
 ---

--- a/1209/7530/index.md
+++ b/1209/7530/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Refflion: IoT Development Board - Bootloader
+owner: PotentialLabs
+license: TAPR Open Hardware License
+site: http://refflion.io/
+source: https://bitbucket.org/PotentialLabs/refflion/
+---
+Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform. This board uses the low cost ESP8266 WiFi Module for Wireless connectivity.

--- a/1209/7530/index.md
+++ b/1209/7530/index.md
@@ -6,3 +6,4 @@ license: TAPR Open Hardware License
 site: http://refflion.io
 source: https://bitbucket.org/PotentialLabs/refflion
 ---
+Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform.

--- a/1209/7530/index.md
+++ b/1209/7530/index.md
@@ -6,4 +6,4 @@ license: TAPR Open Hardware License
 site: http://refflion.io
 source: https://bitbucket.org/PotentialLabs/refflion
 ---
-Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform.
+Refflion is an open source WiFi IoT development board based on the popular Arduino platform.

--- a/1209/7531/index.md
+++ b/1209/7531/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Refflion: IoT Development Board - Sketch
+owner: PotentialLabs
+license: TAPR Open Hardware License
+site: http://refflion.io/
+source: https://bitbucket.org/PotentialLabs/refflion/
+---
+Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform. This board uses the low cost ESP8266 WiFi Module for Wireless connectivity.

--- a/1209/7531/index.md
+++ b/1209/7531/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Refflion - IoT Development Board - Bootloader
+title: Refflion - IoT Development Board - Sketch
 owner: PotentialLabs
 license: TAPR Open Hardware License
 site: http://refflion.io

--- a/1209/7531/index.md
+++ b/1209/7531/index.md
@@ -6,4 +6,4 @@ license: TAPR Open Hardware License
 site: http://refflion.io
 source: https://bitbucket.org/PotentialLabs/refflion
 ---
-Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform.
+Refflion is an open source WiFi IoT development board based on the popular Arduino platform.

--- a/1209/7531/index.md
+++ b/1209/7531/index.md
@@ -1,9 +1,9 @@
 ---
 layout: pid
-title: Refflion: IoT Development Board - Sketch
+title: Refflion - IoT Development Board - Bootloader
 owner: PotentialLabs
 license: TAPR Open Hardware License
-site: http://refflion.io/
-source: https://bitbucket.org/PotentialLabs/refflion/
+site: http://refflion.io
+source: https://bitbucket.org/PotentialLabs/refflion
 ---
-Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform. This board uses the low cost ESP8266 WiFi Module for Wireless connectivity.
+Refflion is an upcoming open source WiFi IoT development board based on the popular Arduino platform.

--- a/org/PotentialLabs/index.md
+++ b/org/PotentialLabs/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: PotentialLabs  
+---
+Embedded Systems and IT R&D Lab


### PR DESCRIPTION
Requesting two VID/PID pairs for Refflion IoT prototyping board which is Arduino compatible and based on the Arduino Leonardo platform.

One VID/PID pair will be used the Arduino bootloader and the other will be used for uploading sketchs.