### PR TITLE
Add the Ja Rule Bootloader ID.

### DIFF
--- a/1209/ACEE/index.md
+++ b/1209/ACEE/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Ja Rule Bootloader
+owner: openlightingproject
+license: LGPL
+site: https://docs.openlighting.org/ja-rule/doc/latest/
+source: https://github.com/OpenLightingProject/ja-rule
+---
+
+DFU Boot loader for the [Ja Rule device](http://pid.codes/1209/ACED/).


### PR DESCRIPTION
Per the DFU 1.1 spec:

... to ensure that only the DFU driver is loaded, it is considered necessary
to change the idProduct field of the device when it enumerates the DFU
descriptor set.

This document does not attempt to specify how a vendor might alter the device’s
product ID except to suggest that adding one, setting the high bit, or using
FFFFh are all valid possibilities. Vendors may use any scheme that they choose.

I went with adding 1 to the Ja Rule product ID.