### PR TITLE
Added Pinscape controller as 1209/EAEA

### DIFF
--- a/1209/EAEA/index.md
+++ b/1209/EAEA/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Pinscape Controller
+title: Controller
 owner: Pinscape
 license: MIT
 site: https://developer.mbed.org/users/mjr/code/Pinscape_Controller/

--- a/1209/EAEA/index.md
+++ b/1209/EAEA/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: Pinscape Controller
+owner: Pinscape
+license: MIT
+site: https://developer.mbed.org/users/mjr/code/Pinscape_Controller/
+source: https://developer.mbed.org/users/mjr/code/Pinscape_Controller/
+---
+The Pinscape Controller is software for the Freescale KL25Z microcontroller
+board that implements an I/O controller for virtual pinball cabinets.  The
+controller provides mechanical analog plunger input sensing (with a couple
+of choices of sensor type), key input, accelerometer-based nudge sensing,
+and feedback device output control.  

--- a/org/Pinscape/index.md
+++ b/org/Pinscape/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Pinscape
+---
+An open source I/O controller for virtual pinball cabinets.


### PR DESCRIPTION
This is an open source software project running on the Freescale KL25Z, which acts as a USB client device when running the project.