### PR TITLE
3DRacers Pilot Board

### DIFF
--- a/1209/FA57/index.md
+++ b/1209/FA57/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: 3DRacers Pilot Board
+owner: 3DRacers
+license: Creative Commons Share-Alike 4.0
+site: http://www.3dracers.com/
+source: http://github.com/3DRacers/PilotBoard
+---

--- a/1209/FA57/index.md
+++ b/1209/FA57/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: 3DRacers Pilot Board
+title: Pilot Board
 owner: 3DRacers
 license: Creative Commons Share-Alike 4.0
 site: http://www.3dracers.com/

--- a/1209/FA58/index.md
+++ b/1209/FA58/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: 3DRacers Pilot Board (Bootloader)
+title: Pilot Board (Bootloader)
 owner: 3DRacers
 license: Creative Commons Share-Alike 4.0
 site: http://www.3dracers.com/

--- a/1209/FA58/index.md
+++ b/1209/FA58/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: 3DRacers Pilot Board (Bootloader)
+owner: 3DRacers
+license: Creative Commons Share-Alike 4.0
+site: http://www.3dracers.com/
+source: http://github.com/3DRacers/PilotBoard
+---

--- a/org/3DRacers/index.md
+++ b/org/3DRacers/index.md
@@ -2,4 +2,4 @@
 layout: org
 title: 3DRacers
 ---
-3DRacers is a fully customizable racing game with mobile app and Open Hardware.
+[3DRacers](http://www.3dracers.com/) is a fully customizable racing game with mobile app and Open Hardware.

--- a/org/3DRacers/index.md
+++ b/org/3DRacers/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: 3DRacers
+---
+3DRacers is a fully customizable racing game with mobile app and Open Hardware.


### PR DESCRIPTION
3DRacers Pilot is an Arduino-compatible board, similar to the Sparkfun
Pro Micro. 
A 3DRacers is a 3D printed RC car, that you can drive with an Arduino or a smartphone App.

The board schematics, sketch code and 3D models are on the
github organization repositories.

It needs 2 PID since the Caterina
bootloader runs on a different PID when activated, while the normal
program code runs on the main PID.