### PR TITLE
Please add Global Boot pid of 0xB007. 

### DIFF
--- a/1209/B007/index.md
+++ b/1209/B007/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Global_Boot
+owner: Konsgn
+license: GPLv2
+site: 
+source: https://github.com/konsgn/Global_Boot
+---
+A universal USB bootloader for microcontrollers based on the halfkay protocol

--- a/1209/B007/index.md
+++ b/1209/B007/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Global_Boot
-owner: Konsgn
+owner: Global_boot
 license: GPLv2
 site: 
 source: https://github.com/konsgn/Global_Boot

--- a/1209/B007/index.md
+++ b/1209/B007/index.md
@@ -1,9 +1,13 @@
 ---
 layout: pid
 title: Global_Boot
-owner: Global_boot
+owner: Konsgn
 license: GPLv2
-site: 
+site: https://github.com/konsgn/Global_Boot
 source: https://github.com/konsgn/Global_Boot
 ---
 A universal USB bootloader for microcontrollers based on the halfkay protocol
+
+This is just a project to make a simple python programmer be able to load code onto various usb capable microcontrollers.
+Within the Global boot firmware directory will be bootloader firmware for various uC's that allow them all to be programmed from the same script.
+The Halfkay protocol was made by Paul J Stoffregen for the teensy platform. 

--- a/org/Global_boot/index.md
+++ b/org/Global_boot/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Global_Boot
+---
+This is just a project to make a simple python programmer be able to load code onto various usb capable microcontrollers.
+Within the Global boot directory will be bootloader firmware for various uC's that allow them all to be programmed from the same script.
+The Halfkay protocol was made by Paul J Stoffregen for the teensy platform. 

--- a/org/Global_boot/index.md
+++ b/org/Global_boot/index.md
@@ -1,7 +1,0 @@
----
-layout: org
-title: Global_Boot
----
-This is just a project to make a simple python programmer be able to load code onto various usb capable microcontrollers.
-Within the Global boot directory will be bootloader firmware for various uC's that allow them all to be programmed from the same script.
-The Halfkay protocol was made by Paul J Stoffregen for the teensy platform. 

--- a/org/Konsgn/index.md
+++ b/org/Konsgn/index.md
@@ -2,4 +2,3 @@
 layout: org
 title: Konsgn
 ---
-Just want a stable pid for a universal bootloader. Woo!

--- a/org/Konsgn/index.md
+++ b/org/Konsgn/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Konsgn
+---
+Just want a stable pid for a universal bootloader. Woo!


### PR DESCRIPTION
I'm trying to make a universal loader for various uC's based on the halfkay protocol. So far I have already made a functional bootloader for the PIC25K50 chips in assembly, so it fits withing the bootsector of that chip. Next attempt will be freescale or ST arm based processors.