### PR TITLE
Add PID for dap42

### DIFF
--- a/1209/DA42/index.md
+++ b/1209/DA42/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: dap42 debug access probe
+owner: devanlai
+lic3ense: LGPLv3
+site: https://github.com/devanlai/dap42
+source: https://github.com/devanlai/dap42
+---
+dap42 is a low cost and low-part-count open source hardware+firmware design for a CMSIS-DAP debug probe for ARM targets using Serial Wire Debug.
+
+It can be used as a standalone debugger or integrated into a larger design as an on-board debugger.

--- a/org/devanlai/index.md
+++ b/org/devanlai/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Devan Lai
+---
+I'm an engineer with that wants to build and use open source tools.


### PR DESCRIPTION
Requesting PID DA42 for my open source/hardware project, [dap42](https://github.com/devanlai/dap42), a very low cost/low part count debugger following the CMSIS-DAP standard.