### PR TITLE
Fix typo

### DIFF
--- a/1209/DA42/index.md
+++ b/1209/DA42/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: dap42 debug access probe
 owner: devanlai
-lic3ense: LGPLv3
+license: LGPLv3
 site: https://github.com/devanlai/dap42
 source: https://github.com/devanlai/dap42
 ---


### PR DESCRIPTION
Sorry, I just noticed that the [license](http://pid.codes/1209/DA42/) doesn't show up because I accidentally injected a 3 into the license keyword when I was messing with my buffers.