### PR TITLE
PID request for 1209/6464 for my GameCube to USB joystick mod

### DIFF
--- a/1209/6464/index.md
+++ b/1209/6464/index.md
@@ -1,8 +1,9 @@
 ---
 layout: pid
 title: Shinewave
-owner: Electric Exploits
+owner: ElectricExploits
 license: MIT
 site: http://electricexploits.net/
 source: https://github.com/GGreenwood/Shinewave
 ---
+This is a completely internal mod for the Nintendo GameCube controller that replaces the stock GameCube connection cord with a USB cord. A custom designed PCB sits inside the controller and houses an ATtiny84 running the micronucleus bootloader and V-USB libraries. It is an HID compliant joystick with reprogrammable LEDs. The project is documented here: http://www.electricexploits.net/gamecube-controller-usb-conversion-mod/

--- a/1209/6464/index.md
+++ b/1209/6464/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Shinewave
+owner: Electric Exploits
+license: MIT
+site: http://electricexploits.net/
+source: https://github.com/GGreenwood/Shinewave
+---

--- a/org/ElectricExploits/index.md
+++ b/org/ElectricExploits/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Electric Exploits
+---
+[Electric Exploits](http://electricexploits.net/) is an electronics blog focusing on low-level hardware development.


### PR DESCRIPTION
Hello! I would like to request a PID for one of my projects. It's an internal USB joystick conversion mod for the Nintendo Gamecube controller. The full source is licensed under MIT and can be found [here](https://github.com/GGreenwood/Shinewave). The firmware and hardware is found under `/firmware` and `/circuit`, respectively.

Thank you for providing this service!

Signed-off-by: Garrett Greenwood <garrettagreenwood@gmail.com>