### PR TITLE
PID request for jj1bdx avrhwrng

### DIFF
--- a/1209/6502/index.md
+++ b/1209/6502/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: avrhwrng v2rev1
+owner: jj1bdx
+license: MIT / CC-BY-4.0
+site: https://github.com/jj1bdx/avrhwrng/
+source: https://github.com/jj1bdx/avrhwrng/
+---

--- a/org/jj1bdx/index.md
+++ b/org/jj1bdx/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: jj1bdx
+---
+jj1bdx is a pseudonym of Kenji Rikitake. Kenji experiments USB serial based hardware random number generators and other devices.


### PR DESCRIPTION
I would like to request a PID for a hardware random number generator (HRNG) circuit/shield for Arduino. With an independent PID, writing a device driver to utilize this HRNG will be easier by automating the identification of this device.
You can find the details at https://github.com/jj1bdx/avrhwrng/