### PR TITLE
PID request for candleLight

### DIFF
--- a/1209/2323/index.md
+++ b/1209/2323/index.md
@@ -1,0 +1,16 @@
+---
+layout: pid
+title: candleLight
+owner: bytewerk.org
+license: MIT, CERN OHL
+site: https://cangaroo.org/candle/light/
+source: https://github.com/HubertD/candleLight
+---
+A cheap, simple USB CAN Adpater
+* made with KiCAD
+* STM32F0 based
+* firmware implements the gs_usb protocol
+* SocketCAN support using the gs_usb kernel module, mainline since linux 3.16
+* supported by cangaroo using WinUSB in MS Windows >=7
+* find the bytewerk guys and grab a candleLight on your favourite CCC event!
+

--- a/1209/2323/index.md
+++ b/1209/2323/index.md
@@ -7,10 +7,8 @@ site: https://cangaroo.org/candle/light/
 source: https://github.com/HubertD/candleLight
 ---
 A cheap, simple USB CAN Adpater
-* made with KiCAD
-* STM32F0 based
-* firmware implements the gs_usb protocol
+* made with KiCAD, STM32F0 based
+* firmware repository: https://github.com/HubertD/candleLight_fw/
 * SocketCAN support using the gs_usb kernel module, mainline since linux 3.16
 * supported by cangaroo using WinUSB in MS Windows >=7
 * find the bytewerk guys and grab a candleLight on your favourite CCC event!
-

--- a/org/bytewerk.org/index.md
+++ b/org/bytewerk.org/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: bytewerk.org
+---
+Hackerspace located in Ingolstadt, Bavaria, Germany.


### PR DESCRIPTION
* Add org/bytewerk.org
* Add 1209/2323

candleLight is a cheap USB CAN adapter with SocketCAN and WinUSB support