### PR TITLE
PID request for the Argentine Open Industrial Computer project

### DIFF
--- a/1209/C1AA/index.md
+++ b/1209/C1AA/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Computadora Industrial Abierta Argentina
-owner: Proyecto CIAA
+owner: ciaa
 license: BSD
 site: http://www.proyecto-ciaa.com.ar/
 source: http://github.com/ciaa/hardware/

--- a/1209/C1AA/index.md
+++ b/1209/C1AA/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Computadora Industrial Abierta Argentina
+owner: Proyecto CIAA
+license: BSD
+site: http://www.proyecto-ciaa.com.ar/
+source: http://github.com/ciaa/hardware/
+---

--- a/org/ciaa/index.md
+++ b/org/ciaa/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Proyecto CIAA
+---
+Argentine Open Industrial Computer Project (Proyecto CIAA - Computadora Industrial Abierta Argentina). An open-source hardware and software platform for industrial applications.
+
+http://www.proyecto-ciaa.com.ar/devwiki/doku.php?id=en:start


### PR DESCRIPTION
Argentine Open Industrial Computer Project (Proyecto CIAA - Computadora Industrial Abierta Argentina). An open-source hardware and software platform for industrial applications.

PID requested: ```0xC1AA```

http://www.proyecto-ciaa.com.ar/devwiki/doku.php?id=en:start
https://github.com/ciaa
