### PR TITLE
Add pid for dapboot

### DIFF
--- a/1209/DB42/index.md
+++ b/1209/DB42/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: dapboot USB DFU bootloader
+owner: devanlai
+license: LGPLv3
+site: https://github.com/devanlai/dapboot
+source: https://github.com/devanlai/dapboot
+---
+dapboot is a USB DFU bootloader for STM32 microcontrollers.


### PR DESCRIPTION
Requesting PID 0xDB42 for dapboot, a USB DFU bootloader that complements my dap42 firmware when running on STM32F103 chips, which don't have an on-chip DFU bootloader.