### PR TITLE
Kosagi palawan -- correct typo

### DIFF
--- a/1209/9317/index.md
+++ b/1209/9317/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: Palawan-Tx
 owner: Kosagi
-license: CC4.0-BY-SA (hardware) / BSD (firmware)
+license: CC4.0-BY-SA (hardware) / MUT (firmware)
 site: https://github.com/xobs/joyboot
 source: https://github.com/xobs/palawan-hw
 ---

--- a/1209/9317/index.md
+++ b/1209/9317/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: Palawan-Tx
 owner: Kosagi
-license: CC4.0-BY-SA (hardware) / MUT (firmware)
+license: CC4.0-BY-SA (hardware) / MIT (firmware)
 site: https://github.com/xobs/joyboot
 source: https://github.com/xobs/palawan-hw
 ---

--- a/1209/9317/index.md
+++ b/1209/9317/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Palawan-Tx
+owner: Kosagi
+license: CC4.0-BY-SA (hardware) / BSD (firmware)
+site: https://github.com/xobs/joyboot
+source: https://github.com/xobs/palawan-hw
+---
+Palawan is an open-source RF stick designed to act as a USB HID device.  It contains a bit-banged USB stack.

--- a/org/Kosagi/index.md
+++ b/org/Kosagi/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Sutajio Ko-Usagi (Kosagi)
+---
+Kosagi makes open hardware and software for fun.


### PR DESCRIPTION
This corrects a typo where "MIT" was spelled "MUT".