### PR TITLE
Chibitronics ltc

### DIFF
--- a/1209/C1B1/index.md
+++ b/1209/C1B1/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Love-to-Code
+owner: chibitronics
+license: CERN OHL 1.2, GPL 3
+site: https://chibitronics.com/
+source: https://chibitronics.com/wiki/index.php?title=LTC
+---
+Love-to-Code is a microcontroller that is programmed via audio.  It has an Arduino-compatible API, and can be programmed with a bit-banged USB stack.

--- a/org/chibitronics/index.md
+++ b/org/chibitronics/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Chibitronics
+site: https://chibitronics.com/
+---
+Chibitronics makes supplies that allow people to craft with paper and electronics.


### PR DESCRIPTION
This adds a new company -- Chibitronics -- and a new product -- Love-to-Code.  It's a sticker that's designed to be programmed via audio, to allow for everyone to learn how to code.

@bunnie gave a talk on the project at 33c3: https://media.ccc.de/v/33c3-7975-making_technology_inclusive_through_papercraft_and_sound

The sticker supports uploading a USB stack via audio, and thus requires a PID.