### PR TITLE
Request for PID D017 for empiriKit controllers

### DIFF
--- a/1209/D017/index.md
+++ b/1209/D017/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: empiriKit Controller
+owner: empiriKit
+license: BSD
+site: http://www.empirikit.com/
+source: http://github.com/empirikit/
+---

--- a/1209/D017/index.md
+++ b/1209/D017/index.md
@@ -4,5 +4,5 @@ title: empiriKit Controller
 owner: empiriKit
 license: BSD
 site: http://www.empirikit.com/
-source: http://github.com/empirikit/
+source: https://github.com/empirikit/empirikit-controller
 ---

--- a/org/empiriKit/index.md
+++ b/org/empiriKit/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: empiriKit
+site: http://www.empirikit.com/
+---
+Provind high quality low cost science class solutions. 
+


### PR DESCRIPTION
In our spare time, we are creating enablers for affordable science controllers/sensors based on different off-the-shelf programmable hardware.

We are in the process of moving some things to WebUSB to ease deployment and use and need a proper VID/PID for the series of devices.

Code will be made available on the github account listed but most currently resides under https://github.com/larsgk

WebUSB and controller in action on example demo page: https://twitter.com/denladeside/status/817451203076427783
