### PR TITLE
Added org and PID F16A for a DIY throttle controller for flight sims

### DIFF
--- a/1209/F16A/index.md
+++ b/1209/F16A/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Cougar TQS adapter
+owner: uri_ba
+license: MIT
+site: https://pit.uriba.org/tag/tqs/
+source: https://github.com/uriba107/cougar_tqs_adapter
+---
+

--- a/org/uri_ba/index.md
+++ b/org/uri_ba/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: uri_ba
+site: http://pit.uriba.org/
+---
+I'm a Hobbyist, an electronics noob which tries his best at building a home cockpit. Which among other things, includes HID controllers for inputs (joysticks and stuff).


### PR DESCRIPTION
This has my First attempt at a USB controller, it's currently set to use either ATMEL testing VID/PID or a "never seen" PID under the Thrustmaster LLC VID. which is naturally very bad thing to do. A dedicatedPID for this project will be mostly appreciated. (I have one or two similar projects in the making, so I'll probably submit a request for a PID for them as well once the code will be finalized and commited).

Cheers,
Uri 