### PR TITLE
PID for GBCartFlasher

### DIFF
--- a/1209/6BCF/index.md
+++ b/1209/6BCF/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Gameboy Cart Flasher
+owner: blaste
+license: GPL V3
+site: https://github.com/melka/gbcartflasher
+source: https://github.com/melka/gbcartflasher
+---
+PCB for the ATmega8515 / FT232 based Gameboy Cart Flasher by Kraku & Chroost, plus some modifications to host software to make it work easily under MacOS

--- a/org/blaste/index.md
+++ b/org/blaste/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: blaste
+site: http://www.blaste.net (in progress)
+---
+blaste is another handle for Kamel Makhloufi / melka. I work on open source hardware projects in my free time, mostly stuff dedicated to creative arts. 

--- a/org/blaste/index.md
+++ b/org/blaste/index.md
@@ -1,6 +1,7 @@
 ---
 layout: org
 title: blaste
-site: http://www.blaste.net (in progress)
+site: http://www.blaste.net
 ---
-blaste is another handle for Kamel Makhloufi / melka. I work on open source hardware projects in my free time, mostly stuff dedicated to creative arts. 
+blaste is another handle for Kamel Makhloufi / melka. I work on open source hardware projects in my free time, mostly stuff dedicated to creative arts.
+Website in construction


### PR DESCRIPTION
Hi,

This is my pull request for a VID / PID pair for a USB gameboy cart flasher. The project was already open sourced by the original developers, but I had to make a couple of changes in order to get it to work easily on MacOS, and one of those changes was to change the VID / PID on an FTDI FT232RL in order to stop MacOS to try and load the default kexts and being able to use libftdi.

Hope you'll accept the request.

Regards,