### PR TITLE
Added PD Buddy organization and PID 9DB5

### DIFF
--- a/1209/9DB5/index.md
+++ b/1209/9DB5/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Sink
+owner: pd-buddy
+license: CERN OHL v1.2 (hardware), GPLv3 (firmware, software)
+site: https://git.clayhobbs.com/pd-buddy
+source: https://git.clayhobbs.com/pd-buddy
+---
+A dead-simple USB PD power sink that gives your project the power it needs, and
+nothing else.

--- a/org/pd-buddy/index.md
+++ b/org/pd-buddy/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: PD Buddy
+site: https://git.clayhobbs.com/pd-buddy
+---
+PD Buddy aims to make USB Power Delivery easy to use for any electronics
+hobbyist.


### PR DESCRIPTION
1209:9DB5 - PD Buddy Sink

PD Buddy Sink is a device I'm making that makes USB Power Delivery easy to use for any electronics hobbyist.  The user configures the Sink with a particular voltage and current, then the Sink requests the user setting from the power supply whenever it's plugged in.  The configuration is done over a USB CDC-ACM interface, so having a non-testing PID for it would be wonderful.

Thanks,
—Clay Hobbs