### PR TITLE
Request PID for FreeSRP software-defined radio

### DIFF
--- a/1209/e1ec/index.md
+++ b/1209/e1ec/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: FreeSRP
+owner: FreeSRP
+license: GPLv3 (software), CC BY-SA 4.0 (hardware)
+site: http://freesrp.org/
+source: http://github.com/FreeSRP
+---

--- a/1209/e1ec/index.md
+++ b/1209/e1ec/index.md
@@ -4,5 +4,5 @@ title: FreeSRP
 owner: FreeSRP
 license: GPLv3 (software), CC BY-SA 4.0 (hardware)
 site: http://freesrp.org/
-source: http://github.com/FreeSRP
+source: https://github.com/myriadrf/freesrp
 ---

--- a/org/FreeSRP/index.md
+++ b/org/FreeSRP/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: FreeSRP
+site: http://freesrp.org/
+---
+The FreeSRP is an open source software-defined radio platform. The hardware includes a wideband, high sample rate transceiver, an FPGA and a USB 3.0 interface, and is expandable through add-ons.


### PR DESCRIPTION
This pull request is to request a PID for the FreeSRP software-defined radio.

The main project website is: http://freesrp.org
And all the source code can be found at: http://github.com/FreeSRP
PDF schematics and USB controller firmware are located here: http://github.com/FreeSRP/usb-firmware

Thank you!