### PR TITLE
USB PID request for Orthrus project

### DIFF
--- a/1209/C0C0/index.md
+++ b/1209/C0C0/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Orthrus
-owner: Geppetto Electronics
+owner: Geppetto_Electronics
 license: GPLv2
 site: https://hackaday.io/project/20772-orthrus
 source: http://github.com/nsayer/Orthrus/

--- a/1209/C0C0/index.md
+++ b/1209/C0C0/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Orthrus
+owner: Geppetto Electronics
+license: GPLv2
+site: https://hackaday.io/project/20772-orthrus
+source: http://github.com/nsayer/Orthrus/
+---

--- a/org/Geppetto/index.md
+++ b/org/Geppetto/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Geppetto Electronics
+site: http://www.geppettoelectronics.com/
+---
+I make and sell little electronic things in low volumes on Tindie.

--- a/org/Geppetto_Electronics/index.md
+++ b/org/Geppetto_Electronics/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
-title: Geppetto Electronics
+title: Geppetto_Electronics
 site: http://www.geppettoelectronics.com/
 ---
 I make and sell little electronic things in low volumes on Tindie.


### PR DESCRIPTION
Hi. The firmware is marked as GPLv2, but it's a mixed license - it heavily draws on LUFA, which is itself MIT licensed. Files I 100% wrote myself are GPLv2. The hardware is open - it's on hackaday.io. I haven't specifically declared an open hardware license, but there is a schematic there as well as EAGLE files for the boards.