### PR TITLE
added PID F16C for a DIY USB adapter for Force Sensing stick module for flight sims

### DIFF
--- a/1209/F16C/index.md
+++ b/1209/F16C/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: USB adapter for Vipercore's FCC3 Force Sensing Module
+owner: uri_ba
+license: MIT
+site: https://pit.uriba.org/tag/fcc/
+source: https://github.com/uriba107/fcc_controller
+---


### PR DESCRIPTION
An Arduino micro (atmega 32u4) based USB controller for flight sims.
Allows to connect a Force sensing mod for Thrunsmaster Cougar without the need to the original thrustmaster PCB. (while gaining a bunch of new features)

Controller code is LUFA based, and MIT licensed (by LUFA's original license)
Controller app is MIT licensed (my code).
 