### PR TITLE
1209: C1B1: update source url

### DIFF
--- a/1209/C1B1/index.md
+++ b/1209/C1B1/index.md
@@ -4,6 +4,8 @@ title: Love-to-Code
 owner: chibitronics
 license: CERN OHL 1.2, GPL 3
 site: https://chibitronics.com/
-source: https://chibitronics.com/wiki/index.php?title=LTC
+source: https://github.com/chibitronics/ltc-chibichip-hardware
 ---
 Love-to-Code is a microcontroller that is programmed via audio.  It has an Arduino-compatible API, and can be programmed with a bit-banged USB stack.
+
+The source code to the operating system is based on ChibiOS, and is available at https://github.com/chibitronics/ltc-os.git


### PR DESCRIPTION
The URL to the hardware source has changed.  It is now available on
the Chibitronics Github page.

Signed-off-by: Sean Cross <sean@xobs.io>