### PR TITLE
Request PID for GHETT-iO

### DIFF
--- a/1209/4748/index.md
+++ b/1209/4748/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: GHETT-iO Bootloader
+owner: kategray
+license: WTFPL
+site: https://github.com/kategray/technomotion-io/tree/master/docs
+source: https://github.com/kategray/technomotion-io/tree/master/GHETT-iO.cydsn
+---
+The GHETT-IO is a plug-and-play solution for connecting Dance Dance Revolution
+dance pads to StepMania.  It's based on the CY8CKIT-059, a $10 board from Cypress
+SemiConductor with open schematics.  This board was chosen for it's low cost and
+easy availability, enabling the community to build these at home by simply
+soldering on a few pin headers.

--- a/org/kategray/index.md
+++ b/org/kategray/index.md
@@ -1,0 +1,8 @@
+---
+layout: org
+title: Kate Gray
+site: http://github.com/kategray/
+---
+I produce open-source software and hardware to work with arcade machines,
+particularly rhythm games like the In The Groove and Dance Dance Revolution
+games.


### PR DESCRIPTION
Hello,

This request is for an update to an active project - adding a HID bootloader.  I'm working to fill a need in the community where arcade hardware keeps failing.  Rather than designing a custom board, I've used an off-the-shelf [board](http://www.cypress.com/documentation/development-kitsboards/cy8ckit-059-psoc-5lp-prototyping-kit-onboard-programmer-and) that's available in ridiculous quantities for $10.  

I want as many people as possible to make parts for machines, so the source is open.  The source for the cypress board is available, as well as the parts list - Cypress doesn't assert any intellectual rights over the design, but has not specifically open-sourced it.  For those who want a clearly open source hardware model, I also support the FreeSOC, which is open source hardware (for those who want a completely open solution).

It's licensed under the WTFPL, which is GPL-compatible.  I place no restrictions on the intellectual property whatsoever, however, given the differences in jurisdictions approach to Copyright, I did not want to simply place it in the public domain.

![ghett-io](https://user-images.githubusercontent.com/2415200/27416061-16067f46-56d9-11e7-8622-ec1f9c221a22.jpg)
![ghett-io-wiring](https://user-images.githubusercontent.com/2415200/27416062-18b7204c-56d9-11e7-8052-b190e077ebd1.jpg)
