### PR TITLE
PID request for mooware Wii and SNES to USB adapters

### DIFF
--- a/1209/2A00/index.md
+++ b/1209/2A00/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Wii USB adapter
+owner: mooware
+license: MIT
+site: https://github.com/mooware/arduino-wii-usb
+source: https://github.com/mooware/arduino-wii-usb
+---
+Arduino-based USB-adapter for Wii/WiiU controllers.
+
+Works with the Classic Controller, Hori Battle Pad, NES Classic Mini Controller and most likely the SNES Classic Mini Controller.

--- a/1209/2A01/index.md
+++ b/1209/2A01/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SNES USB adapter
+owner: mooware
+license: MIT
+site: https://github.com/mooware/arduino-nes-snes-usb
+source: https://github.com/mooware/arduino-nes-snes-usb
+---
+Arduino-based USB-adapter for SNES controllers.

--- a/org/mooware/index.md
+++ b/org/mooware/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: mooware
+site: https://github.com/mooware
+---
+I'm just a software developer doing hobbyist arduino stuff.


### PR DESCRIPTION
Hi,

I'd like USB PIDs for my controller adapters. The different adapters should have different PIDs so that emulator software will let me configure them differently.

Thanks.