### PR TITLE
PID for Wirekite

### DIFF
--- a/1209/317E/index.md
+++ b/1209/317E/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Wirekite
+owner: Codecrete
+license: MIT
+site: https://github.com/manuelbl/Wirekite/wiki
+source: https://github.com/manuelbl/Wirekite
+---
+Wire up analog and digital IOs and I2C to your Mac or Windows computer using a Teensy board. Control them from Swift, Objective-C, C# or Visual Basic .NET code.

--- a/org/Codecrete/index.md
+++ b/org/Codecrete/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Codecrete
+site: https://www.codecrete.net
+---
+Open source software and hardware - initiated by Manuel Bleichenbacher


### PR DESCRIPTION
New organization: Codecrete
New PID for Wirekite

Wirekite allows you to wire up analog and digital inputs and outputs including I2C to your Mac or Windows computer. Based on Teensy LC/3.2 (open source hardware). A Windows and Mac library allow to communicate via USB with the Wirekite and control the IOs.