### PR TITLE
Add DirtyJTAG pid code

### DIFF
--- a/1209/C0CA/index.md
+++ b/1209/C0CA/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: DirtyJTAG
+owner: jeanthom
+license: MIT
+site: https://github.com/jeanthom/DirtyJTAG
+source: https://github.com/jeanthom/DirtyJTAG
+---
+JTAG adapter firmware for STM32F1 dev boards

--- a/org/jeanthom/index.md
+++ b/org/jeanthom/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Jean THOMAS
+---
+Electronics, computer & co.


### PR DESCRIPTION
DirtyJTAG is an opensource JTAG adapter firmware I created for STM32F1 boards. It needs its own PID codes as it uses its own protocol to communicate with host software.