### PR TITLE
O'Doom Fx

### DIFF
--- a/1209/0D02/index.md
+++ b/1209/0D02/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: O'Doom Fx - Twin MIDI Stomper
+owner: odoom
+license: AGPL3.0
+site: https://odoom.github.io
+source: https://github.com/odoom/twin-midi-stomper
+---

--- a/1209/0D02/index.md
+++ b/1209/0D02/index.md
@@ -4,5 +4,5 @@ title: O'Doom Fx - Twin MIDI Stomper
 owner: odoom
 license: AGPL3.0
 site: https://odoom.github.io
-source: https://github.com/odoom/twin-midi-stomper
+source: https://github.com/odoom/midi-stomper/tree/master/twin_midi_stomper
 ---

--- a/org/odoom/index.md
+++ b/org/odoom/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: O'Doom
+site: https://odoom.github.io
+---
+O'Doom is a small hardware company. We are making guitar effects pedals, midi controllers, and guitar amps. Our hardware designs and software will be open source so users can repair them or build them from scratch for personal use.


### PR DESCRIPTION
O'Doom is a small hardware company. We are making guitar effects pedals, midi controllers, and guitar amps. Our hardware designs and software will be open source so users can repair them or build them from scratch for personal use.