### PR TITLE
PID request for Monero Hardware firmware(s) and one bootloader (#293)

### DIFF
--- a/1209/B0B0/index.md
+++ b/1209/B0B0/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Monero Bootloader
+owner: Monero Hardware
+license: CERN
+site: https://getmonero.org/
+source: https://github.com/monero-project/kastelo/
+---
+The Monero Hardware Wallet, a Open Source and secure cryptodevice

--- a/1209/C0DA/index.md
+++ b/1209/C0DA/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Monero Firmware
+owner: Monero Hardware
+license: CERN
+site: https://getmonero.org/
+source: https://github.com/monero-project/kastelo/
+---
+The Monero Hardware Wallet, a Open Source and secure cryptodevice

--- a/1209/D00D/index.md
+++ b/1209/D00D/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Monero Developer
+owner: Monero Hardware
+license: CERN
+site: https://getmonero.org/
+source: https://github.com/monero-project/kastelo/
+---
+The Monero Hardware Wallet, a Open Source and secure cryptodevice

--- a/org/Monero/index.md
+++ b/org/Monero/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Monero Hardware
+site: https://getmonero.org/
+---
+[Monero Hardware](https://getmonero.org/) is a team of hardware loving cryptoscientists based in the heart of Europe. Our projects include the first hardware Monero wallet.


### PR DESCRIPTION
The two (instead of one) firmware PIDs map to two different device types (with different architectures) we plan to release.