### PR TITLE
70B1: add Tomu tiny USB device

### DIFF
--- a/1209/70B1/index.md
+++ b/1209/70B1/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Tomu
+owner: Kosagi
+license: CC-BY-SA
+site: https://tomu.im/
+source: https://github.com/im-tomu/tomu-hardware
+---
+Tomu is a USB device that fits entirely inside your USB port.


### PR DESCRIPTION
Claim PID 70B1 for Tomu.

Signed-off-by: Sean Cross <sean@xobs.io>