### PR TITLE
add 4 PIDs for the keyplus split keyboard firmware

### DIFF
--- a/1209/BB00/index.md
+++ b/1209/BB00/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: split keyboard firmware
+owner: keyplus
+license: MIT, CC-BY-SA, CC-BY-NC
+site: http://keyplus.io
+source: https://github.com/ahtn/keyplus
+---
+
+This PID is for the keyplus keyboard firmware running on Xmega microcontrollers.

--- a/1209/BB01/index.md
+++ b/1209/BB01/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: xusb bootloader
+owner: keyplus
+license: MIT, CC-BY-SA, CC-BY-NC
+site: http://keyplus.io
+source: https://github.com/ahtn/xusb-boot
+---
+
+A USB raw HID bootloader for AVR XMEGA microcontrollers.

--- a/1209/BB02/index.md
+++ b/1209/BB02/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: nRF24 wireless keyboard dongle
+owner: keyplus
+license: MIT
+site: http://keyplus.io
+source: https://github.com/ahtn/keyplus
+---
+
+This PID is for the keyplus keyboard firmware running on on a nRF24LU1+ USB
+dongle.

--- a/1209/BB03/index.md
+++ b/1209/BB03/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: nrf24lu1p-512 bootloader
+owner: keyplus
+license: MIT
+site: http://keyplus.io
+source: https://github.com/ahtn/nrf24lu1p-512-bootoader
+---
+
+A 512 byte USB bootloader for the nRF24LU1+.

--- a/org/keyplus/index.md
+++ b/org/keyplus/index.md
@@ -1,0 +1,8 @@
+---
+layout: org
+title: keyplus
+site: http://keyplus.io
+---
+
+Keyplus is a keyboard firmware project for making easy to use wired and wireless
+split keyboards.


### PR DESCRIPTION
The 4 requested PIDs are:

* BB00: Split keyboard firmware running on AVR XMEGA microcontrollers.
* BB01: USB HID bootloader for AVR XMEGA microcontrollers.
* BB02: Wireless keyboard dongle for keyplus keyboards (nRF24LU1+ based)
* BB03: USB HID bootloader for nRF24LU1+

Note I don't have hardware files for the nRF24LU1+ dongle. Since the nRF24LU1+ code only uses USB and the nRF24 radio, it should be possible to use the firmware on any existing nRF24LU1+ dongle without hardware modifications. For this reason, I didn't reinvent my own hardware for this part of the project.