### PR TITLE
PIDs for arthroscopic surgery skills trainers

### DIFF
--- a/1209/2800/index.md
+++ b/1209/2800/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Triangulation
+owner: Entropic_Engineering
+license: Apache2
+site: http://demo.xlms.org
+source: https://github.com/EntropicEngineering/orthoboxes
+PCBs: https://github.com/EntropicEngineering/orthobox-hardware
+---
+Triangulation Orthobox (pokey)

--- a/1209/2801/index.md
+++ b/1209/2801/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Object Manipulation
+owner: Entropic_Engineering
+license: Apache2
+site: http://demo.xlms.org
+source: https://github.com/EntropicEngineering/orthoboxes
+PCBs: https://github.com/EntropicEngineering/orthobox-hardware
+---
+Object Manipulation Orthobox (peggy)

--- a/org/Entropic_Engineering/index.md
+++ b/org/Entropic_Engineering/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Entropic Engineering
+site: http://www.entropicengineering.com
+---
+Engineering consulting firm specializing in embedded computing & product prototyping.


### PR DESCRIPTION
Entropic Engineering has developed the electronics and software for a pair of arthroscopic skills trainers, which are being commercialized and sold by Sawbones (www.sawbones.com) based on a research project developed at the University of Minnesota.