### PR TITLE
PID request for GEX USB module and wireless dongle

### DIFF
--- a/1209/4c60/index.md
+++ b/1209/4c60/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: GEX USB module
+owner: MightyPork
+license: MPLv2
+site: https://gexpander.github.io/
+source: https://github.com/gexpander
+---
+GEX is a general purpose input/output module with a USB or wireless 
+connection that provides user-friendly access to low-level hardware 
+buses and functions using a high-level programming interface.

--- a/1209/4c60/index.md
+++ b/1209/4c60/index.md
@@ -4,7 +4,7 @@ title: GEX USB module
 owner: MightyPork
 license: MPLv2
 site: https://gexpander.github.io/
-source: https://github.com/gexpander
+source: https://github.com/gexpander/gex-core https://github.com/gexpander/gex-hardware
 ---
 GEX is a general purpose input/output module with a USB or wireless 
 connection that provides user-friendly access to low-level hardware 

--- a/1209/4c61/index.md
+++ b/1209/4c61/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: GEX wireless dongle
+owner: MightyPork
+license: MPLv2
+site: https://gexpander.github.io/
+source: https://github.com/gexpander
+---
+USB dongle providing wireless access to GEX modules.

--- a/org/MightyPork/index.md
+++ b/org/MightyPork/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: MightyPork
+site: https://www.ondrovo.com/
+---
+My name is Ondřej Hruška, I'm a hobbyist working on 
+fun embedded projects and open source software.


### PR DESCRIPTION
- 4c60: the module with a USB port for configuration and high-speed wired operation
- 4c61: a dongle that will provide wireless access for outdoors / hazardous installations

Firmware all MPLv2, hardware CC-BY-SA 3.0