### PR TITLE
Adding organization "nerilex" and allocating 1209:C311 for GB-USB-Link

### DIFF
--- a/1209/C311/index.md
+++ b/1209/C311/index.md
@@ -1,0 +1,17 @@
+---
+layout: pid
+title: GB-USB-Link
+owner: nerilex
+license: GPL 3
+site: https://c0de.pw/bg/gb-usb-link
+source: https://c0de.pw/bg/gb-usb-link
+---
+GB-USB-Link is a firmware for [STLink/v2][1] clones which turns them into 
+[GameBoy Printer][2] emulators.
+
+Additionally [GB-USB-Link-host][3] (also GPLv3) is needed on the computer to
+function as emulator (it saves the images as PNG files).
+
+[1]: https://wiki.paparazziuav.org/wiki/STLink#Clones
+[2]: https://en.wikipedia.org/wiki/Game_Boy_Printer
+[3]: https://c0de.pw/bg/gb-usb-link-host

--- a/org/nerilex/index.md
+++ b/org/nerilex/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: bg nerilex
+---
+I am an engineer / developer / hacker / ... with a focus on embedded systems and
+crypto but occasionaly a lot of other things to.


### PR DESCRIPTION
GB-USB-Link is an alternate firmware for ST-Link/v2 clones which turns them into GameBoy-Printer emulators. The firmware and the host software are distributed under GPLv3.