### PR TITLE
Request for a pid for Iowa Scaled Engineering's derivation of

### DIFF
--- a/1209/6570/index.md
+++ b/1209/6570/index.md
@@ -1,0 +1,16 @@
+---
+layout: pid
+title: CKT-AVRPROGRAMMER
+owner: IowaScaledEngineering
+license: GPL v2 (software) / CC BY-SA (hardware)
+site: https://github.com/IowaScaledEngineering/ckt-avrprogrammer
+source: https://github.com/IowaScaledEngineering/ckt-avrprogrammer
+---
+The CKT-AVRPROGRAMMER is a derivation of the various USBtinyISP
+programmers, such as SparkFun's Pocket AVR Programmer or Adafruit's
+USBtinyISP, that includes the ability to power either a 3.3V or 5V target
+and has inrush/target short protection.  
+
+We would ideally like to make this an open VID/PID that all open derivations of
+Dick Streefland's original USBtinyISP programmer can share, since there is
+currently no "open" VID/PID that these derivations can use.

--- a/org/IowaScaledEngineering/index.md
+++ b/org/IowaScaledEngineering/index.md
@@ -1,0 +1,11 @@
+---
+layout: org
+title: Iowa Scaled Engineering, LLC
+site: https://www.iascaled.com
+---
+Iowa Scaled Engineering, LLC, is a partnership between Nathan Holmes and
+Michael Petersen that creates open source hardware and software, primarily
+for model railroad and electronic hobbyist use.
+
+
+


### PR DESCRIPTION
Request for a pid for Iowa Scaled Engineering's derivation of the USBtinyISP programmer.  While Dick Streefland's firmware (later modified by Adafruit and Sparkfun) is free software and the various programmers (including ours) are open hardware, Adafruit's VID/PID are restricted per their contract with USB-IF.  

While we'd like one allocated for our use, we'd also like to suggest that it could become a shared PID across anyone implementing the original USBtiny firmware or derived/compatible open software on open hardware, in the spirit of sharing.