### PR TITLE
PID request for libtransistor USB serial console

### DIFF
--- a/1209/8B00/index.md
+++ b/1209/8B00/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Libtransistor Serial Console
+owner: ReSwitched
+license: ISC
+site: https://github.com/reswitched/libtransistor/
+source: https://github.com/reswitched/libtransistor/blob/development/lib/usb_serial.c
+---

--- a/org/ReSwitched/index.md
+++ b/org/ReSwitched/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: ReSwitched
+site: https://reswitched.tech/
+---
+Reverse engineering the Nintendo Switch, and developing tools to enable homebrew.


### PR DESCRIPTION
I'm an author for libtransistor, a library for developing applications to run on the Nintendo Switch. We have recently added serial console functionality over USB for debug output, and would like to have a PID so that we can request that our serial console be recognized by the Linux [usb-serial-simple driver](https://github.com/torvalds/linux/blob/master/drivers/usb/serial/usb-serial-simple.c) without having to steal someone else's VID/PID.