### PR TITLE
Request for PIDs for NBS-DAC 192/24

### DIFF
--- a/1209/8242/index.md
+++ b/1209/8242/index.md
@@ -1,9 +1,10 @@
 ---
 layout: pid
-title: NBS-DAC 192/24
+title: NBS-DAC 192/24 UAC1
 owner: TomWimmenhoveElectronics
 license: GPL
 site: http://nbsdac.tomwimmenhove.com/
 source: http://nbsdac.tomwimmenhove.com/
 ---
+Since this is a USB audio-device that supports both USB Audio Class 1 and USB Audio Class 2, it needs 2 PIDs. One for each class. This is the PID for USB Audio Class 1 (UAC1)
 

--- a/1209/8242/index.md
+++ b/1209/8242/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: NBS-DAC 192/24
+owner: TomWimmenhoveElectronics
+license: GPL
+site: http://nbsdac.tomwimmenhove.com/
+source: http://nbsdac.tomwimmenhove.com/
+---
+

--- a/1209/8243/index.md
+++ b/1209/8243/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: NBS-DAC 192/24 UAC2
+owner: TomWimmenhoveElectronics
+license: GPL
+site: http://nbsdac.tomwimmenhove.com/
+source: http://nbsdac.tomwimmenhove.com/
+---
+Since this is a USB audio-device that supports both USB Audio Class 1 and USB Audio Class 2, it needs 2 PIDs. One for each class. This is the PID f
+or USB Audio Class 2 (UAC2)
+

--- a/org/TomWimmenhoveElectronics/index.md
+++ b/org/TomWimmenhoveElectronics/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Tom Wimmenhove Electronics
+site: http://www.tomwimmenhove.com/
+---
+Used to do some contracting work. Now, mostly hobby software/firmware/electronics-related stuff.
+


### PR DESCRIPTION
This is a request for two PIDs (8242 and 8243) for a USB Audio DAC. One PID for each supported USB Audio Class (UAC1 and UAC2).