### PR TITLE
request PID for kp_boot_32u4 bootloader

### DIFF
--- a/1209/BB05/index.md
+++ b/1209/BB05/index.md
@@ -1,0 +1,16 @@
+---
+layout: pid
+title: kp_boot_32u4 bootloader
+owner: keyplus
+license: MIT
+site: https://github.com/ahtn/kp_boot_32u4
+source: https://github.com/ahtn/kp_boot_32u4
+---
+
+A USB HID bootloader for AVR USB microcontrollers in the U2, U4 and
+AT90USB series.  Features include:
+
+* only 1kB code size
+* supports writing flash, eeprom and lock bits
+* an SPM interface so application code can modify its own flash
+* it uses a raw HID interface, so it doesn't require drivers on windows


### PR DESCRIPTION
Hi,

There's quite a few bootloaders around for the 32u4 series of microcontrollers, but none of them had the feature set I needed, so I made this one:

* small 1kB code size
* supports writing flash, eeprom and lock bits
* an SPM interface so application code can modify its own flash
* it uses a raw HID interface, so it doesn't require drivers on windows

There's no hardware files for this project because it's hardware independent, and I'll probably mostly use it with the Arduino Pro Micro which is an open source design.

I can use my other PID `BB00` for the main firmware application.