### PR TITLE
Remove unused PID 0x3452

### DIFF
--- a/1209/3452/index.md
+++ b/1209/3452/index.md
@@ -1,9 +1,0 @@
----
-layout: pid
-title: Temp monitor
-owner: TempMonitor
-license: MIT, GPLv2, MPL 2.0
-site: http://tempmonitor.github.io/
-source: http://github.com/Tempmonitor/Tempmonitor
----
-Temp monitor is a device that shows system resources such as CPU and GPU temperature.

--- a/org/TempMonitor/index.md
+++ b/org/TempMonitor/index.md
@@ -1,5 +1,0 @@
----
-layout: org
-title: Temp monitor
----
-Temp monitor consists of a group of students devloping an external system monitor for computers as part of a school project. More information can be found on our website http://tempmonitor.github.io/


### PR DESCRIPTION
Hello!

Unfortunately the PID 0x3452 was never used and can therefore be removed. The organisation "Temp monitor" is also only associated with this PID and can be removed as well.

This pull request removes both the PID association 0x3456 and organisation "Temp monitor".