### PR TITLE
USB DFU Bootloader for SAMDx1

### DIFF
--- a/1209/2003/index.md
+++ b/1209/2003/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: SAMDx1-USB-DFU-Bootloader
+owner: majbthrd
+license: BSD 3-Clause
+site: https://github.com/majbthrd/SAMDx1-USB-DFU-Bootloader
+source: https://github.com/majbthrd/SAMDx1-USB-DFU-Bootloader
+---

--- a/1209/2488/index.md
+++ b/1209/2488/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: CMSIS-DAP Dapper Miser
+owner: majbthrd
+license: Apache 2.0
+site: https://github.com/majbthrd/DapperMiser/
+source: https://github.com/majbthrd/DapperMiser/
+---


### PR DESCRIPTION
lightweight (1kB rather than existing 4kB or more) USB bootloader for the Atmel/Microchip SAMD11 and SAMD21 microcontrollers conforming to the USB DFU protocol