### PR TITLE
PID Request for SAMR21-Mote

### DIFF
--- a/1209/053A
+++ b/1209/053A
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: HSSV SAMR21-Mote
+owner: hackerspacesv
+license: APACHE 2.0
+site: https://github.com/hackerspacesv/contiki-hardware
+source: https://github.com/hackerspacesv/contiki-hardware
+---
+The HSSV is the breakout development board for the ATSAMR21 IoT module running Contiki-OS.

--- a/1209/053A
+++ b/1209/053A
@@ -1,9 +1,0 @@
----
-layout: pid
-title: HSSV SAMR21-Mote
-owner: hackerspacesv
-license: APACHE 2.0
-site: https://github.com/hackerspacesv/contiki-hardware
-source: https://github.com/hackerspacesv/contiki-hardware
----
-The HSSV is the breakout development board for the ATSAMR21 IoT module running Contiki-OS.

--- a/1209/053A/index.md
+++ b/1209/053A/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: HSSV SAMR21-Mote
+owner: hackerspacesv
+license: APACHE 2.0
+site: https://github.com/hackerspacesv/contiki-hardware
+source: https://github.com/hackerspacesv/contiki-hardware
+---
+The HSSV SAMR21-Mote is the development board for the ATSAMR21 IoT module running Contiki-OS.

--- a/org/hackerspacesv/index.md
+++ b/org/hackerspacesv/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Hackerspace San Salvador
+site: http://hackerspace.teubi.co/
+---
+The Hackerspace San Salvador is the first hackerspace in El Salvador. We are focused on hardware and embedded development for IoT.


### PR DESCRIPTION
This pull requests adds the organization information for the Hackerspace San Salvador, and a new PID request for the development board HSSV SAMR21-Mote. The device shows as an USB-CDC device to allow the use of the SLIP protocol to connect to 802.15.4 networks.