### PR TITLE
Big Switch PCB by flehrad

### DIFF
--- a/1209/B195/index.md
+++ b/1209/B195/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Big Switch PCB
+owner: flehrad
+license: Apache 2
+site: https://github.com/flehrad/Big-Switch-PCB
+source: https://github.com/qmk/qmk_firmware/tree/master/keyboards/bigswitch
+
+---
+
+An open source PCB for the NovelKeys.xyz Big Switch series of mechanical switches.

--- a/org/flehrad/index.md
+++ b/org/flehrad/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: flehrad
+site: https://www.youtube.com/channel/UCg98oJZNffR9nDLJNkorjqw
+---
+Don of The Board Podcast, everything mechanical keyboard related, and designer of custom keyboard PCBs.


### PR DESCRIPTION
Requesting a PID (B195) for the Big Switch PCB, powered by a pro micro and QMK
firmware. I contributed the firmware port and Don of the board u/flehrad
created the PCB and open sourced it's design.