### PR TITLE
PID request (BEBA) for the STM32 HID bootloader

### DIFF
--- a/1209/BEBA/index.md
+++ b/1209/BEBA/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: STM32 HID Bootloader
+owner: serasidis.gr
+license: GPL 3.0
+site: https://github.com/Serasidis/STM32_HID_Bootloader
+source: https://github.com/Serasidis/STM32_HID_Bootloader
+---
+This is a driverless (no USB drivers needed, even on Windows) USB HID bootloader for STM32F devices.
+That project is based on brunofreitas HID bootloader work.

--- a/org/serasidis.gr/index.md
+++ b/org/serasidis.gr/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: serasidis.gr
+site: http://www.serasidis.gr/
+---
+Electronic circuits based on AVR and STM32 micro-controllers


### PR DESCRIPTION
This is a driverless (no USB drivers needed, even on Windows) USB HID bootloader for STM32 devices.
The STM32 HID bootloader is very small (less than 4 KB)
It is customized for using it with [Arduino_STM32 ](https://github.com/rogerclarkmelbourne/Arduino_STM32) + [Arduino IDE](https://www.arduino.cc/en/Main/Software)
It supports the STM32F1xx series but the plan is to support the STM32F4xx series too.
 
This repo is based on bootsector's stm32-hid-bootloader repository but is customized to follows the STM32duino ecosystem requirements. The source files can be compiled on Windows, Linux or Mac platform