### PR TITLE
PID request for ProgHQ TL866II Plus

### DIFF
--- a/1209/8662/index.md
+++ b/1209/8662/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: ProgHQ TL866II Plus programmer
+owner: ProgHQ
+license: BSD-2-Clause 
+site: https://github.com/ProgHQ
+source: https://github.com/ProgHQ/open-tl866
+---


### PR DESCRIPTION
* Request for a PID for the Open Source firmware version of the TL866II
  Plus EPROM programmer.