### PR TITLE
PID request for BeebLink.

### DIFF
--- a/1209/BEEB/index.mb
+++ b/1209/BEEB/index.mb
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: BeebLink
+owner: tom-seddon
+license: GPLv3
+site: https://github.com/tom-seddon/beeblink
+source: https://github.com/tom-seddon/beeblink
+---
+A file storage system for the BBC Micro.

--- a/org/tom-seddon/index.md
+++ b/org/tom-seddon/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Tom Seddon
+site: https://github.com/tom-seddon
+---
+UK-based software developer.


### PR DESCRIPTION
BeebLink is a file storage system for the BBC Micro, an 8-bit computer that was popular in the UK.

The USB device is an AVR with some firmware that acts a fairly straightforward intermediary between the PC (USB I/O) and the BBC Micro (GPIO-based I/O).

Thanks,

--Tom