### PR TITLE
1209:1776: System76 Thelio Io

### DIFF
--- a/1209/1776/index.md
+++ b/1209/1776/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Thelio Io
+title: System76 Thelio Io
 owner: System76
 license: GPLv3
 site: https://thel.io/

--- a/1209/1776/index.md
+++ b/1209/1776/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Thelio Io
+owner: System76
+license: GPLv3
+site: https://thel.io/
+source: http://github.com/system76/thelio-io/
+---

--- a/org/System76/index.md
+++ b/org/System76/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: System76
+site: https://system76.com/
+---
+System76 is a computer manufacturer specializing in the sale of laptops, desktops, and servers running Linux.


### PR DESCRIPTION
I am requesting 1209:1776 for use for our System76 Thelio Io board. Both the firmware and hardware are licensed GPLv3.

Here are the repositories:

- https://github.com/pop-os/system76-io-dkms
- https://github.com/system76/thelio-io-firmware
- https://github.com/system76/thelio-io-hardware