### PR TITLE
Allocate a PID for the FluxEngine.

### DIFF
--- a/1209/6E00/index.md
+++ b/1209/6E00/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: FluxEngine
+owner: cowlark
+license: MIT
+site: http://cowlark.com/
+source: http://github.com/davidgiven/fluxengine
+---
+A PSoc5LP-based floppy disk controller, capable of reading and writing
+arbtirary flux patterns to standard PC floppy drives.
+

--- a/org/cowlark/index.md
+++ b/org/cowlark/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Cowlark Technologies
+site: http://cowlark.com/
+---
+Hobbyist development by David Given <dg@cowlark.com>.
+


### PR DESCRIPTION
This allocates a PID for a project I'm working on: a USB-attached floppy drive controller intended for accessing non-PC disk formats on a standard PC drive, based on an off-the-shelf Cypress PSoc5 evaluation kit.

It's still under development, but works fine in read mode (and works a little in write mode). It's MIT licensed.