### PR TITLE
PID request for Lednice generic led device

### DIFF
--- a/1209/5716/index.md
+++ b/1209/5716/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Lednice
+owner: ResNullius
+license: GPLv2
+site: https://github.com/jpirko/lednice
+source: https://github.com/jpirko/lednice
+---
+Generic USB led device implementation.

--- a/org/ResNullius/index.md
+++ b/org/ResNullius/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: ResNullius
+site: http://resnulli.us/
+---
+Open source factory owned by Jiri Pirko (one man show).


### PR DESCRIPTION
Please check out: https://github.com/jpirko/lednice
This is an example implementation of the generic led USB device for Digispark (attiny85) under GPLv2 licence. So this is a open firmware project. The interface is generic and extendable so it would be easy for people to create more sophisticated led devices.