### PR TITLE
Request pid 0x2440 for the GnuPG Verein.

### DIFF
--- a/1209/2440/index.md
+++ b/1209/2440/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: An OpenPGP Token
+owner: GnuPG-Verein
+license: GPLv3, CC BY-SA 3.0
+site: https://gnupg.org/verein/token.html
+source: https://gnupg.org/verein/token.html
+---
+
+A crypto token for the members of the Verein (with the Verein's
+OpenPGP manufacturer id) and others (using other manufacturer ids or
+the random manufacturer id range).

--- a/org/GnuPG-Verein/index.md
+++ b/org/GnuPG-Verein/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: GnuPG e.V.
+site: https://gnupg.org/verein
+---
+
+The GnuPG e.V. (The Verein) is a charitable entity supporting the
+development of GnuPG and other privacy solutions.  The Verein is also
+the registar for OpenPGPcard manufacturer IDs.


### PR DESCRIPTION
We like to hand out tokens as well as giving everyone an opportunity to use this hardware and software for their own idea on how to implement an OpenPGP compliant token.  For interoperability it would be good to have a dedicated VID/PID for such small series of tokens.  After all the different implementations can apply for a free manufacturer ID (according to the OpenPGP card specs) and use this to distinguish their implementations.  Due to the usual problems the VID of the FSIJ can't be used for own experiments or tokens and thus the missing VID/PID is  major hurdle to deploy such tokens.

FWIW, 2440 is the original RFC number for OpenPGP.  4880 being the current one but I hesitate to ask for two PIDs just to reserve it.