### PR TITLE
SoloKeys PID code application

### DIFF
--- a/1209/5070/index.md
+++ b/1209/5070/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: SoloHacker
+owner: SoloKeys
+license: GPL-3.0-or-later
+site: https://solokeys.com/
+source: https://github.com/solokeyssec/
+---
+Solo Key hacker edition. Open source FIDO2 and more!
+

--- a/1209/50B0/index.md
+++ b/1209/50B0/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SoloBoot
+owner: SoloKeys
+license: GPL-3.0-or-later
+site: https://solokeys.com/
+source: https://github.com/solokeyssec/
+---
+SoloKeys bootloader. Easy signed firmware updates!

--- a/org/SoloKeys/index.md
+++ b/org/SoloKeys/index.md
@@ -1,0 +1,5 @@
+layout: org
+title: SoloKeys
+site: https://solokeys.com
+---
+Open source security tokens. GPLv3 and CC BY-SA.


### PR DESCRIPTION
For our open source FIDO2 security token, we have an official
vid/pid of 0483/a2ca from STMicroelectronics. We use this for
the consumer product, which is locked down for safety reasons,
allowing only firmware updates signed by us via our bootloader.

We would like to set a separate PID of 50B0 for this bootloader.

For enthusiasts, we offer the "hacker" edition of the key, which
allows arbitrary (unsigned or self-signed) firmware to be loaded.
It would be great to use a separate PID of 5070 for this.

Please let me know if any modifications are needed (in particular,
I used GPL-3.0-or-later, and didn't see a way to set the hardware
license in the individual PID applications).

Thanks a lot for this service,
Nicolas