### PR TITLE
Request PID ABB9 for the bootloader of SafeWISE

### DIFF
--- a/1209/ABB9/index.md
+++ b/1209/ABB9/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SafeWISE Bootloader
+owner: CoinWISE
+license: GNU Affero General Public License v3.0
+site: https://safewise.io/
+source: https://github.com/coinwise-io/safewise-hardware
+---
+SafeWISE is a fork of the TREZOR hardware wallet, that in the future will follow a different development roadmap. Currently, the SafeWISE firmware is the same as the TREZOR firmware (https://github.com/trezor/trezor-mcu).


### PR DESCRIPTION
Some months ago we had requested the PID ABBA and you had approved our request. In the next versions of SafeWISE firmware (following the firmware of Trezor One), the bootloader will have a different PID than the main firmware. So we are requesting one more PID for the bootloader.