### PR TITLE
Add `1209:DEED` for the `Kroneum` device.

### DIFF
--- a/1209/DEED/index.md
+++ b/1209/DEED/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Kroneum
+owner: azasypkin
+license: MIT License
+site: https://github.com/azasypkin/kroneum
+source: https://github.com/azasypkin/kroneum
+---
+Kroneum is a minimalist, accessible (no GUI) and fully open source (both in code and hardware) time tracker device.

--- a/org/azasypkin/index.md
+++ b/org/azasypkin/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Aleh Zasypkin
+site: https://github.com/azasypkin
+---
+I'm a software engineer with a huge passion for hardware, mechanical design and manufacturing.


### PR DESCRIPTION
I'd like to ask for `DEED` PID for my [Kroneum](https://github.com/azasypkin/kroneum) device. It's an experimental (yet), minimalist, accessible (no GUI) and fully open source (both in code and hardware) time tracker device.

* Source code: https://github.com/azasypkin/kroneum
* License: https://github.com/azasypkin/kroneum/blob/master/LICENSE
* Software: https://github.com/azasypkin/kroneum/tree/master/sw (firmware + cli tool, [USB related code](https://github.com/azasypkin/kroneum/blob/master/sw/firmware/bin/src/usb.rs))
* Hardware: https://github.com/azasypkin/kroneum/tree/master/hw/pcb/Rev_0.3

Thank you!