### PR TITLE
Added additional testing codes for multi-device scenarios

### DIFF
--- a/1209/0002/index.md
+++ b/1209/0002/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0003/index.md
+++ b/1209/0003/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0004/index.md
+++ b/1209/0004/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0005/index.md
+++ b/1209/0005/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0006/index.md
+++ b/1209/0006/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0007/index.md
+++ b/1209/0007/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0008/index.md
+++ b/1209/0008/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0009/index.md
+++ b/1209/0009/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/000a/index.md
+++ b/1209/000a/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/000b/index.md
+++ b/1209/000b/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/000c/index.md
+++ b/1209/000c/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/000d/index.md
+++ b/1209/000d/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/000e/index.md
+++ b/1209/000e/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/000f/index.md
+++ b/1209/000f/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/1209/0010/index.md
+++ b/1209/0010/index.md
@@ -1,0 +1,7 @@
+---
+layout: pid
+title: Test PID
+owner: pidcodes
+license: any
+---
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.


### PR DESCRIPTION
This PR adds 15 additional testing PIDs from 0002 to 0010 inclusive. These additional PIDs will allow a developer to test multiple distinct devices simultaneously, or to switch from one device under development to another device without worrying about driver mismatches or WinUSB cache hits.