### PR TITLE
Added Robotics-Masters and the MM1 Hat

### DIFF
--- a/1209/4D40/index.md
+++ b/1209/4D40/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MM1 Hat - Base
+owner: Robotics-Masters
+license: OHL
+site: https://robotics-masters.co/
+source: https://github.com/robotics-masters/mm1-hat-schematics/
+---
+MM1 Hat

--- a/1209/4D40/index.md
+++ b/1209/4D40/index.md
@@ -1,9 +1,0 @@
----
-layout: pid
-title: MM1 Hat - Base
-owner: Robotics-Masters
-license: OHL
-site: https://robotics-masters.co/
-source: https://github.com/robotics-masters/mm1-hat-schematics/
----
-MM1 Hat

--- a/1209/4D41/index.md
+++ b/1209/4D41/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MM1 Hat - MSC Bootloader
+owner: Robotics-Masters
+license: MIT
+site: https://robotics-masters.co/
+source: https://github.com/robotics-masters/uf2-samdx1/
+---
+MSC UF2 Bootloader for MM1 Hat

--- a/1209/4D42/index.md
+++ b/1209/4D42/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MM1 Hat - SeeSaw
+owner: Robotics-Masters
+license: GPLv3
+site: https://robotics-masters.co/
+source: https://github.com/robotics-masters/seesaw/
+---
+I2C-I/O Bridge using the SeeSaw interface for MM1 Hat

--- a/1209/4D43/index.md
+++ b/1209/4D43/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MM1 Hat - CircuitPython
+owner: Robotics-Masters
+license: MIT
+site: https://robotics-masters.co/
+source: https://github.com/robotics-masters/circuitpython/
+---
+CircuitPython for MM1 Hat

--- a/1209/4D44/index.md
+++ b/1209/4D44/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: MM1 Hat - Bootloader
 owner: Robotics-Masters
-license: MIT
+license: GPLv3
 site: https://robotics-masters.co/
 source: https://github.com/robotics-masters/mm1-hat-bootloader/
 ---

--- a/1209/4D44/index.md
+++ b/1209/4D44/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MM1 Hat - Bootloader
+owner: Robotics-Masters
+license: MIT
+site: https://robotics-masters.co/
+source: https://github.com/robotics-masters/mm1-hat-bootloader/
+---
+UF2 Bootloader for MM1 Hat

--- a/1209/4D45/index.md
+++ b/1209/4D45/index.md
@@ -4,6 +4,6 @@ title: MM1 Hat - Arduino
 owner: Robotics-Masters
 license: GPLv3
 site: https://robotics-masters.co/
-source: https://github.com/robotics-masters/arduino/
+source: https://github.com/robotics-masters/mm1-hat-arduino/
 ---
 Arduino Serial Port for MM1 Hat

--- a/1209/4D45/index.md
+++ b/1209/4D45/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MM1 Hat - Arduino
+owner: Robotics-Masters
+license: GPLv3
+site: https://robotics-masters.co/
+source: https://github.com/robotics-masters/arduino/
+---
+Arduino Serial Port for MM1 Hat

--- a/org/Robotics-Masters/index.md
+++ b/org/Robotics-Masters/index.md
@@ -1,0 +1,10 @@
+---
+layout: org
+title: Robotics Masters
+site: https://robotics-masters.co/
+---
+Accelerate, Build and Create for an Autonomous World.
+Enable everyone to be skilled in Robotics and AI.
+
+Robotics Masters is building educational robot platforms that enable people to embrace an autonomous world.
+We give everyone a chance to learn about current and future automation technologies.


### PR DESCRIPTION
We support a set of different bootloaders and firmware choices for our board to make it as accessible as possible for the different communities, for this reason we request differnet VID for each of the boards usecases.
We are working on adding Ardupilot and Dronecode support at the moment and would like to request continuous VIDs 0x4D46 and 0x4D47 for the programming USB device in those i the near future.