### PR TITLE
Request PID for Infinite Noise TRNG for use with kernel module

### DIFF
--- a/1209/3701/index.md
+++ b/1209/3701/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Infinite Noise TRNG
+owner: 13-37.org
+license: CC0
+site: https://www.13-37.org
+source: http://github.com/13-37-org/infnoise
+---
+open source true random number generator

--- a/org/13-37.org/index.md
+++ b/org/13-37.org/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: 13-37.org electronics
+site: https://13-37.org
+---
+open source hardware shop


### PR DESCRIPTION
currently using the VID/PID by the FTDI chip in a user-space driver, need a unique PID to probe for a kernel module (under development)