### PR TITLE
Add Foosn and Fomu

### DIFF
--- a/1209/5BF0/index.md
+++ b/1209/5BF0/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Fomu
+owner: Foosn
+license: CC-BY-SA
+site: https://tomu.im/fomu-evt3
+source: https://github.com/im-tomu/fomu-hardware
+---
+Fomu is an FPGA that fits entirely inside your USB port.

--- a/org/Foosn/index.md
+++ b/org/Foosn/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Foosn
+---
+Foosn is a Singapore-based producer of boutique hardware.


### PR DESCRIPTION
Foosn is a spinoff of Kosagi, and is actually doing design and production of Fomu.

Fomu is an ICE40UP5K FPGA in the same form factor as Tomu -- fitting entirely inside a USB port.