### PR TITLE
Created PID 7102

### DIFF
--- a/1209/7102/index.md
+++ b/1209/7102/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Mini SAM M0
+owner: bshockley
+license: MIT
+site: https://www.minisam.cc
+source: https://github.com/bwshockley/Mini-SAM
+---
+[Benjamin Shockley Github - Mini SAM M0](https://github.com/bwshockley/Mini-SAM) is a minifigure shaped development board.  License files located on the Github repository.


### PR DESCRIPTION
Created PID 7102 for Mini SAM M0 Boards. I currently have one other PID, 1207, for another Mini SAM board.  I have two I have created using different MCUs.  I'd like to be able to have a different Product ID for each board, as such this request is for the second PID.

My organization is 'bshockley'.