### PR TITLE
Zissou PID application

### DIFF
--- a/1209/CC1D/index.md
+++ b/1209/CC1D/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Zissou
+owner: nickray
+license: Apache-2.0 OR MIT
+site: https://zissou.dev/
+source: https://code.zissou.dev/
+---
+PIV-like smartstick firmware in Rust.

--- a/org/nickray/index.md
+++ b/org/nickray/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: nickray
+site: https://nickray.dev/
+---
+Embedded projects in Rust.


### PR DESCRIPTION
As announced in https://github.com/pidcodes/pidcodes.github.com/pull/429, I would like to separately apply for PID `CC1D` for my Rust smartcard project. The code is Apache/MIT dual-licensed. Regarding host hardware: currently it runs on [ST Nucleo L432KC](https://www.st.com/en/evaluation-tools/nucleo-l432kc.html). It will certainly run also on SoloKeys hardware, but the code is built generically to use the Rust [embedded-hal traits](https://github.com/rust-embedded/embedded-hal) and [USB](https://github.com/mvirkkunen/usb-device) [implemen](https://github.com/nickray/stm32l43x-usbd)[tations](https://github.com/Disasm/stm32-usbd), and I plan ports to at minimum the [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle), and eventually the [NXP LPC55S69 EVK](https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc5500-cortex-m33/lpcxpresso55s69-development-board:LPC55S69-EVK) and hopefully a custom USB dongle based on that chip.

The reason I apply already now (the project is work-in-progress, but does answer-to-reset successfully) is that in order to integrate with the [standard open source CCID driver](https://ccid.apdu.fr/), the USB descriptor needs to [be added](https://salsa.debian.org/rousseau/CCID/tree/master/readers) to that repository; lookup on whether a CCID "reader" is "supported" is done via VID/PID pair lookup.

Cheers, and thanks again for this great service!


P.S. I am planning to register an ISO/IEC 7816-5 "registered application provider identifier" (RID), and hand out "proprietary application identifier extensions" (PIX) to open source projects, similar to what you are doing here (the PIX can be up to 11 bytes, so there is even more to distribute than in your PID case). Perhaps you can share your experiences running such a service out of band at some point? I'm @nickray on IRC (freenode) also.