### PR TITLE
Request PID 0x6060 for keyboard

### DIFF
--- a/1209/6060/index.md
+++ b/1209/6060/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: r68 65% keyboard
+owner: rpedde
+license: GPLv2 (or later)
+site: http://github.com/rpedde/r68
+source: http://github.com/rpedde/r68
+---

--- a/org/rpedde/index.md
+++ b/org/rpedde/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Ron Pedde
+site: http://github.com/rpedde
+---
+Various open source hardware and software for fun and amusement.
+Mostly but not exclusively keyboards.


### PR DESCRIPTION
QMK based firmware in /qmk, hardware in kicad in /schematic
with gerbers linked from the README.

All under GPL2 (or later)