### PR TITLE
Request PID 0x4223 for Fluepdot

### DIFF
--- a/1209/4223/index.md
+++ b/1209/4223/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: fluepdot
+owner: fluepke
+license: AGPLv3
+source: https://gitlab.com/fluepke/fluepdot
+---
+

--- a/org/fluepke/index.md
+++ b/org/fluepke/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: fluepke
+---
+I'm fluepke and I program computers.


### PR DESCRIPTION
Hi,

requesting to add me as an organization and PID 0x4223 for a flipdot driver board.
KiCAD schematics and layout can be found under [`/hardware/fluepboard/`](https://gitlab.com/fluepke/fluepdot/tree/master/hardware/fluepboard).

All under [GNU AGPLv3](https://gitlab.com/fluepke/fluepdot/blob/master/LICENSE)