### PR TITLE
Request 7D00 and 7D01 for RIOT devices

### DIFF
--- a/1209/7D00/index.md
+++ b/1209/7D00/index.md
@@ -1,0 +1,14 @@
+---
+layout: pid
+title: RIOT standard peripherals
+owner: RIOT
+license: LGPL-2.1-only
+site: http://riot-os.org/
+source: https://github.com/RIOT-OS/RIOT
+---
+This PID describes devices that contain the board's USB-emulated peripherals (currently CDC-ACM (serial) and/or CDC-ECM (Ethernet)).
+
+It is not bound to a particular hardware and can be used by any RIOT board that has a USB peripheral implemented.
+
+It is only applicable to programs that run no own USB code but merely use the peripherals provided by the operating system to satisfy the module requirements of the application.
+Those USB devices stand in for special-purpose hardware (UART adapter, Ethernet controller) available on other boards.

--- a/1209/7D01/index.md
+++ b/1209/7D01/index.md
@@ -1,0 +1,15 @@
+---
+layout: pid
+title: RIOT Test PID
+owner: RIOT
+license: any
+site: http://riot-os.org/
+source: https://github.com/RIOT-OS/RIOT
+---
+This PID describes devices that implement custom USB functionality in addition to their board's provided USB functionality as described for [PID 7D00](../7D00/).
+
+In particular, it is used whenever an example program of RIOT implements custom USB functionality.
+
+The pid.codes policy for test PIDs applies:
+
+This PID is reserved for use in private testing. Anyone may assign it to their device while they're testing in-house, but it MUST NOT be used on any device that will be redistributed, sold, or manufactured. Source code and configuration that references this VID/PID should warn users that the PID is not universally unique and should not be used outside test environments.

--- a/org/RIOT/index.md
+++ b/org/RIOT/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: RIOT Operating System
+site: http://riot-os.org//
+---
+RIOT: The friendly Operating System for the Internet of Things.


### PR DESCRIPTION
This creates an organization for [RIOT-OS](http://riot-os.org/), and assigns

* PID 7D00 for devices that use the operating system's built-in peripherals in lieu of the hardware parts often found on development boards. (For example, most boards supported by RIOT have an on-board USB-serial adapter wired to the chip; some newer boards don't have that and rely on the main controller's USB port to be connected to the host and provide shell functionality directly).
* PID 7D01 for devices that run the RIOT-OS USB stack but run any custom software atop of that. It is similar to the test PIDs and even applies the same policy. The ID is requested primarily for the purpose of being the default PID for the example programs shipped with RIOT, but phrased as test PIDs because one expectation around the example programs is that people start tinkering with them and slowly develop their own applications from them. The RIOT build system will show a warning to users to get own PIDs when they use these codes.
* It is expected that a few more codes are requested in the future, e.g. when a USB-based DFU bootloader is implemented, or when there is a unified board testing application.

Neither of those are bound to a particular hardware platform, as RIOT supports a plethora of those. Due to the hardware abstractions provided by RIOT, the same user code running on those different boards can be regarded as the same product for the purpose of PID assignment in my opinion.

This request has been discussed on several channels beforehand, among them https://github.com/RIOT-OS/RIOT/issues/12273 on the RIOT side of things.