### PR TITLE
Add Parkrrrr org and 1209/BD10 PID for bdiohid

### DIFF
--- a/1209/BD10/index.md
+++ b/1209/BD10/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: BDIOHID
+owner: Parkrrrr
+license: GPLv3
+site: https://github.com/parkrrrr/bdio/
+source: https://github.com/parkrrrr/bdio/
+---
+BDIOHID is software that runs on a suitable Linux SBC to provide Braille HID (USB-IF HID HUTRR-78) functionality to
+legacy refreshable Braille display hardware. 

--- a/org/Parkrrrr/index.md
+++ b/org/Parkrrrr/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Ron Parker
+site: https://parkrrrr.github.io/
+---
+I'm just a guy who does Windows when I'm not melting windows.


### PR DESCRIPTION
[BDIOHID](https://github.com/parkrrrr/bdio) is a software-only project, because it is intended to run on any Linux SBC, such as the OrangePi Zero+ or the NanoPi NEO, that can run OpenWRT and has both USB host and USB device ports. 

When running, it translates proprietary communications protocols used by legacy Braille displays into [the recently-standardized HID Braille protocol](https://www.usb.org/sites/default/files/hutrr78_-_creation_of_a_braille_display_usage_page_0.pdf). This standard provides a number of benefits to the visually-impaired community, not least of which is a significantly lowered barrier to entry for software developers wishing to provide Braille input and output. I consider BDIOHID to be an integral part of that step forward, in that it endeavors to provide a path forward for users who have older hardware.

We cannot simply replicate the VID and PID from the original Braille hardware, because in many cases that VID and PID are tied to existing host drivers. For example, the HIMS SyncBraille, the first display supported by this project, is based on an FTDI FT232 USB-to-serial chip, so it is inextricably tied to the FTDI serial driver. So, even though this device exists only as a collection of bits on commodity hardware, it needs its own VID/PID.
