### PR TITLE
Request PID 4D69 for Greaseweazle

### DIFF
--- a/1209/4D69/index.md
+++ b/1209/4D69/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Greaseweazle
+owner: KeirFraser
+license: Unlicense
+site: http://www.github.com/keirf/Greaseweazle/wiki
+source: http://github.com/keirf/Greaseweazle
+---
+Greaseweazle is a USB-to-floppy bridge. It reads and writes
+floppy disks at the flux level.

--- a/org/KeirFraser/index.md
+++ b/org/KeirFraser/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Keir Fraser
+site: https://github.com/keirf
+---
+UK-based retro and embedded software developer.


### PR DESCRIPTION
The firmware is in the src/ folder of the Greaseweazle repo.
The host software (Python) is in the scripts/ folder of the Greaseweazle repo.

Hardware is the Blue Pill STM32 board coupled with an adapter PCB, KiCad sources for which are at https://github.com/keirf/PCB-Projects

There is also an STM32F7 based board for which schematics, BOM, and Gerbers are supplied in the Greaseweazle wiki (https://github.com/keirf/Greaseweazle/wiki/STM32F730-Board#design-files)