### PR TITLE
Requesting PID FFB0 for OpenFFBoard

### DIFF
--- a/1209/FFB0/index.md
+++ b/1209/FFB0/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: OpenFFBoard
+owner: Yannick Richter
+license: MIT
+site: https://github.com/Ultrawipf/OpenFFBoard
+source: https://github.com/Ultrawipf/OpenFFBoard
+---
+
+OpenFFBoard is a modular force feedback interface for DIY simulation devices

--- a/1209/FFB0/index.md
+++ b/1209/FFB0/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: OpenFFBoard
-owner: Yannick Richter
+owner: YannickRichter
 license: MIT
 site: https://github.com/Ultrawipf/OpenFFBoard
 source: https://github.com/Ultrawipf/OpenFFBoard

--- a/org/YannickRichter/index.md
+++ b/org/YannickRichter/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Yannick Richter
+site: https://y-richter.de/
+---
+Developing hardware and software for different projects


### PR DESCRIPTION
OpenFFBoard is a modular interface for DIY force feedback devices.
The USB part consists of a composite usb device for CDC and HID.
Currently in early development but with working prototypes.