### PR TITLE
PID Request for NullWiiCon (0x2231)

### DIFF
--- a/1209/2231/index.md
+++ b/1209/2231/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: NullWiiCon
+owner: Nullstalgia
+license: GPLv3
+site: https://github.com/nullstalgia/NullWiiCon/
+source: https://github.com/nullstalgia/NullWiiCon/
+---
+An adapter for retro-style controllers for use on game consoles and personal computers.

--- a/org/Nullstalgia/index.md
+++ b/org/Nullstalgia/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Nullstalgia
+site: http://nullstalgia.me/
+---
+An enthusiast who loves making projects to make life more fun and simple!


### PR DESCRIPTION
NullWiiCon is a configurable, versatile adapter for NES/SNES Classic Controllers, Wii Classic Controllers, etc. Has switchable firmwares for Nintendo Switch, XInput, RetroArch, etc.

KiCad Projects and Source code on https://github.com/nullstalgia/NullWiiCon

OSHWA Cert: https://certification.oshwa.org/us000234.html