### PR TITLE
PID request for USB-to-serial adapter

### DIFF
--- a/1209/8048/index.md
+++ b/1209/8048/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: USB-to-serial adapter
+owner: Codecrete
+license: MIT
+site: https://github.com/manuelbl/usb-serial/
+source: https://github.com/manuelbl/usb-serial/
+---
+USB-to-serial adapter without the need for proprietary drivers. Can be implemented with very few components.


### PR DESCRIPTION
Pull request to add a new PID for the open-source hardware and firmware of a USB-to-serial adapter that can be used without installing any proprietary drivers (as it implements the USB CDC ACM protocol). Built around a crystal-less USB design using a STM32F042 MCU.