### PR TITLE
Request PID C550 for ch55xduino

### DIFF
--- a/1209/C550/index.md
+++ b/1209/C550/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: ch55xduino
+owner: Think Create
+license: LGPL
+site: https://github.com/DeqingSun/ch55xduino
+source: https://github.com/DeqingSun/ch55xduino
+---
+ch55xduino is an Arduino-like programming API for the CH55X, a family of low-cost MCS51 USB MCU. The project tries to remove the difficulty of setting up a compiling environment. 

--- a/org/ThinkCreate/index.md
+++ b/org/ThinkCreate/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Think Create
+site: http://thinkcreate.us/
+---
+Think Create designs and builds electronic prototypes and interactive installations.


### PR DESCRIPTION
ch55xduino is a fork of open-sourced project sduino. At this moment the project barely compiles and all updates are in the playground branch, not the default branch. 