### PR TITLE
Add Command Deck device (requesting VID 1209 / PID F0DA)

### DIFF
--- a/1209/F0DA/index.md
+++ b/1209/F0DA/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: Command Deck
+owner: Hyades
+license: MIT
+site: https://github.com/kamushadenes/commanddeck
+source: https://github.com/kamushadenes/commanddeck_leonardo
+---
+Command Deck is an open-source, tech-savvy alternative to Stream Deck-like devices, allowing you to assign several actions to a single key on a 4x4 keypad.
+
+It can be used with software like Emacs, Vim, OBS and basically anything that accepts keyboard commands.
+
+Mainly, such devices are useful for streamer to perform quick reactions to content, but many workflows are possible. I personally use it for coding.

--- a/org/Hyades/index.md
+++ b/org/Hyades/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Hyades
+site: https://hyades.io
+---
+An one-man organisation with projects focused on information security.


### PR DESCRIPTION
Command Deck is an open-source, tech-savvy alternative to Stream Deck-like devices, allowing you to assign several actions to a single key on a 4x4 keypad.

It can be used with software like Emacs, Vim, OBS and basically anything that accepts keyboard commands.

Mainly, such devices are useful for streamer to perform quick reactions to content, but many workflows are possible. I personally use it for coding.