### PR TITLE
Added own organisation and PID

### DIFF
--- a/1209/5304/index.md
+++ b/1209/5304/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: USB thermocouple logger
+owner: richardklingler
+license: MIT
+site: http://www.mysite.com/
+source: https://github.com/richardklingler/usbthermocouple
+---

--- a/1209/5304/index.md
+++ b/1209/5304/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: USB thermocouple logger
-owner: richardklingler
+owner: klingler
 license: MIT
 site: http://www.mysite.com/
 source: https://github.com/richardklingler/usbthermocouple

--- a/org/klingler/index.md
+++ b/org/klingler/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Klingler
+site: http://www.fpga.ch/
+---
+I am a private engineer focussed on developing open source hardware and software and simple evaluation kits.
+This is my first USB project which evolved through another project soon to be published (SMT reflow pizza oven with USB)


### PR DESCRIPTION
First published USB project on Github, a simple 2-channel thermocouple sensor logger.
A new  version will be published soon based on existing design, and will use the same PID regardless if it is a 2-channel or 8-channel device.