### PR TITLE
Added lophtware's USB2.0 Type-C / PIC32 Breakout Board.

### DIFF
--- a/org/lophtware/1209/cb0b/index.md
+++ b/org/lophtware/1209/cb0b/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: USB Type-C / PIC32 Breakout and Development Board
+owner: lophtware
+license: MIT and CC-BY-SA 4.0
+site: https://www.lophtware.co.uk/
+source: https://github.com/lophtware/UsbCPic32Breakout/
+---
+A USB2.0 Full-Speed Type-C board based on a PIC32 with a 1A +3.3V LDO for prototyping and breadboarding.

--- a/org/lophtware/index.md
+++ b/org/lophtware/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: lophtware
+site: https://www.lophtware.co.uk/
+---
+A man in his loft.


### PR DESCRIPTION
Hello,

This is to request a VID / PID of 0x1209 / 0xcb0b for the firmware that ships with my USB breadboarding widget.  The various sites are still being thrown together but the GitHub repository has all of the code, schematics, etc. so should meet the requirements set out in http://pid.codes/howto/

Any problems or questions, let me know.

Thank you.
