### PR TITLE
ErgoKB Phoenix Board

### DIFF
--- a/1209/2304/index.md
+++ b/1209/2304/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Phoenix Board
+owner: ErgoKB
+license: GPLv3
+site: https://www.ergokb.tw/
+source: https://github.com/ErgoKB/Phoenix
+---

--- a/org/ErgoKB/index.md
+++ b/org/ErgoKB/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: ErgoKB
+site: https://github.com/ErgoKB
+---
+ErgoKB is mainly developing firmwares, hardwares, assistant tools for opensource ergonomic keyboards.


### PR DESCRIPTION
Requesting a PID for the ErgoKB Phoenix ergonomic keyboard. The hardware part is done, and latter on the firmware will use [QMK](https://github.com/qmk/qmk_firmware) and use the PID in it.

Thanks very much!