### PR TITLE
Add uwmisl org and PurpleDrop PID

### DIFF
--- a/1209/CCAA/index.md
+++ b/1209/CCAA/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: PurpleDrop
+owner: uwmisl
+license: MIT
+site: purpledrop.io
+source: http://github.com/uwmisl/purpledrop
+---

--- a/org/uwmisl/index.md
+++ b/org/uwmisl/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: UW Molecular Information Systems Lab
+site: https://misl.cs.washington.edu/
+---
+The Molecular Information Systems Lab (MISL) at the University of Washington explores the intersection of information technology and molecular-level manipulation using in-silico and wet lab experiments.


### PR DESCRIPTION
PurpleDrop is an open-source digital microfluidic project created by researchers and graduate students at the University of Washington. 

The hardware design can be found here: https://github.com/uwmisl/purpledrop
And the embedded software here: https://github.com/uwmisl/purpledrop-stm32