### PR TITLE
add rrainey organization and associated pid codes

### DIFF
--- a/1209/2021/index.md
+++ b/1209/2021/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: AGC DSKY Alarm Panel Replica
+owner: rrainey
+license: CC-BY-SA 4.0
+site: https://github.com/rrainey
+source: https://github.com/rrainey/DSKY-alarm-panel-replica
+---

--- a/1209/2022/index.md
+++ b/1209/2022/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: AGC DSKY Keyboard Replica
+owner: rrainey
+license: CC-BY-SA 4.0
+site: https://github.com/rrainey
+source: https://github.com/rrainey/DSKY-keyboard-replica
+---

--- a/org/rrainey/index.md
+++ b/org/rrainey/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Riley Rainey
+site: https://github.com/rrainey
+---
+I'm the creator of several Open Hardware projects.


### PR DESCRIPTION
Hi. I have created two new open hardware projects and I'm finding that I need distinct PID codes in order to interact with some development tools and drivers cleanly.