### PR TITLE
Request PID 2344 for MoaRGB project

### DIFF
--- a/1209/2344/index.md
+++ b/1209/2344/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: MoaRGB
+owner: jaseg
+license: AGPLv3
+source: https://git.jaseg.de/moargb.git
+---
+

--- a/1209/2344/index.md
+++ b/1209/2344/index.md
@@ -5,4 +5,4 @@ owner: jaseg
 license: AGPLv3
 source: https://git.jaseg.de/moargb.git
 ---
-
+MoaRGB is a high-power RGB LED controller with a self-documenting CDC-compatible interface.


### PR DESCRIPTION
MoaRGB is a high-power RGB LED controller with a self-documenting CDC-compatible interface.