### PR TITLE
add LinklayerLabs org and CANtact Pro device (0x1209/0x1111)

### DIFF
--- a/1209/1111/index.md
+++ b/1209/1111/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: CANtact Pro
+owner: LinklayerLabs
+license: MIT
+site: https://cantact.io
+source: https://github.com/linklayer/cantact/cantact-pro-fw
+---
+CANtact Pro CAN to USB interface.

--- a/org/LinklayerLabs/index.md
+++ b/org/LinklayerLabs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
-title: My organisation
-site: http://www.linklayer.com/
+title: Linklayer Labs
+site: https://www.linklayer.com/
 ---
 Linklayer Labs builds open source hardware tools. Our [CANtact](https://cantact.io) devices are open source Controller Area Network to USB interfaces.

--- a/org/LinklayerLabs/index.md
+++ b/org/LinklayerLabs/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: My organisation
+site: http://www.linklayer.com/
+---
+Linklayer Labs builds open source hardware tools. Our [CANtact](https://cantact.io) devices are open source Controller Area Network to USB interfaces.


### PR DESCRIPTION
Hello, I'd like a VID/PID for the new CANtact Pro device. This is an open source hardware / firmware CAN to USB tool. The VID/PID will be used for an updated driver which enables CAN-FD.
