### PR TITLE
Requests USB ID 1209:3845

### DIFF
--- a/1209/3845/index.md
+++ b/1209/3845/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MyFirstMacroPad
+owner: Eeble
+license: CC BY SA
+site: http://github.com/eeble/myfirstmacropad/
+source: http://github.com/eeble/myfirstmacropad/
+---
+This is a work in progress, but I would like to reserve the PID as I work on the firmware.

--- a/org/Eeble/index.md
+++ b/org/Eeble/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Eeble
+site: http://www.eeble.net/
+---
+I'm a sole hobbyist starting out building some keyboards/macropads and other USB enabled devices.


### PR DESCRIPTION
Requests the USB PID 3845 for a new macropad keyboard in current
development.  Hardware is built and firmware is being written using QMK.

Keyboard specific code to be added to QMK will be placed in the qmk directory in the myfirstmacropad repository