### PR TITLE
Add registration of a default product ID for PAPPL-based printer appl…

### DIFF
--- a/1209/8011/index.md
+++ b/1209/8011/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Printer Application Framework (PAPPL)
+owner: OpenPrinting
+license: Apache2.0
+site: https://www.msweet.org/pappl
+source: https://github.com/michaelrsweet/pappl
+---
+PAPPL is a simple C-based framework/library for developing CUPS Printer
+Applications, which are the recommended replacement for printer drivers.

--- a/org/OpenPrinting/index.md
+++ b/org/OpenPrinting/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: OpenPrinting
+site: https://openprinting.github.io
+---
+OpenPrinting works on the development of printing technology for Linux and
+Unix-style operating systems.  We collaborate with the IEEE-ISTO Printer
+Working Group (PWG) for Internet Printing Protocol (IPP) projects.
+


### PR DESCRIPTION
…ications

running on embedded Linux devices - PID 8011 corresponds to IPP's RFC 8011...

(This project was started by me and will move under the OpenPrinting organization once we have the 1.0 release ready...)
