### PR TITLE
Request 1209/3320 for MJS2020 sensor board

### DIFF
--- a/1209/3320/index.md
+++ b/1209/3320/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: MJS2020: Meetjestad sensor station 2020
+owner: Meetjestad
+license: CERN-OHL-W
+site: https://www.meetjestad.net
+source: https://github.com/meetjestad/mjs_pcb/tree/MJS2020
+---
+This board is intended to collect various weather and other sensor
+measurements for the Meet Je Stad! project. It is a complete redesign of
+the original sensor station from 2016 and includes native USB to
+simplify programming by users.

--- a/org/Meetjestad/index.md
+++ b/org/Meetjestad/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: Meet je stad!
+site: https://www.meetjestad.net/
+---
+Meet je stad! (Dutch for "Measure your city") is a citizen science
+initiative around climate and climate change. Among other things, the
+project has designed open hardware intended to do fine grained
+measurement of wheather and climate parameters within cities.


### PR DESCRIPTION
This board is still in development, but the latest prototype version is already published with full sources, the final board will be published in the same place. The same USB id will be used for the prototype and final versions.