### PR TITLE
Add tzarc org, Djinn keyboard PID reservation.

### DIFF
--- a/1209/4919/index.md
+++ b/1209/4919/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Djinn Mechanical Keyboard
+owner: tzarc
+license: GPLv3
+site: https://github.com/tzarc/djinn
+source: https://github.com/tzarc/djinn
+---
+The Djinn is a 64-key split keyboard -- dual 4x7 with a 4-key thumb cluster. It also has a 5-way tactile hat switch under the thumb, as well as RGB and displays.

--- a/org/tzarc/index.md
+++ b/org/tzarc/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Nick Brassel (@tzarc)
+site: https://github.com/tzarc/
+---
+Mechatronics engineer, mechanical keyboard hobbyist.


### PR DESCRIPTION
Requesting the allocation of 1209:4919 for the [Djinn mechanical keyboard](https://github.com/tzarc/djinn).

The link above points at the hardware design files -- the readme on that repository has links to the corresponding QMK firmware to build.