### PR TITLE
Add electric.ktichen org & PID (0x6F00) for Pulsar Buddy project

### DIFF
--- a/1209/6F00/index.md
+++ b/1209/6F00/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Pulsar Buddy
+owner: electric.kitchen
+license: BSD, CC BY-SA 3.0
+site: https://github.com/mzero/pulsar-buddy/wiki
+source: https://github.com/mzero/pulsar-buddy
+---
+Pulsar Buddy is a small clock unit for the SOMA Lab's Pulsar-23 synth.
+It is also useful with other modular synths.

--- a/org/electric.kitchen/index.md
+++ b/org/electric.kitchen/index.md
@@ -1,0 +1,11 @@
+---
+layout: org
+title: electric.kitchen
+site: https://electric.kitchen/
+---
+electric.kitchen is the electronic music project of Mark Lentczner.
+
+Besides music, the project also creates open source hardware and software
+for creation of electronic music.
+
+Repositories can be found at https://github.com/mzero.


### PR DESCRIPTION
I'd like to request a PID for my open source HW/SW project Pulsar Buddy, a clocking device for electronic music in odd time signatures.

This commit includes both my organization file, and the file for unused PID 6F00.

Thanks!