### PR TITLE
1209/3933: add Sinara/Booster

### DIFF
--- a/1209/3933/index.md
+++ b/1209/3933/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Booster
+owner: Sinara
+license: GPLv3.0+, CERN OHL v1.2
+site: https://github.com/sinara-hw/booster
+source: https://github.com/sinara-hw/booster-firmware
+---
+Booster is a 8-channel radio-frequency power amplifier.


### PR DESCRIPTION
* preferred pid 0x3933 as 0x391e (Sinara magic) plus 21 (Sinara Booster board_id)
* c.f. 1209/392F (Stabilizer)

* Licenses:

https://github.com/sinara-hw/booster-firmware/blob/master/LICENSE
https://github.com/sinara-hw/Booster/blob/master/LICENSE