### PR TITLE
PID request for CombineReality

### DIFF
--- a/1209/9001/index.md
+++ b/1209/9001/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: North Star Integrator
-owner: Combine Reality
+owner: CombineReality
 license: cc-bt-sa-4.0
 site: combinereality.org
 source: https://github.com/CombineReality/North-Star-Integrator ; 

--- a/1209/9001/index.md
+++ b/1209/9001/index.md
@@ -5,7 +5,7 @@ owner: Combine Reality
 license: cc-bt-sa-4.0
 site: combinereality.org
 source: https://github.com/CombineReality/North-Star-Integrator ; 
-Based on lilyPadUSB-caterina, for use with the Combine Reality North Star Integrator board: https://github.com/CombineReality/ArduinoCore-avr
+
 ---
 
 The North Star Integrator is a purpose-built USB hub 

--- a/1209/9001/index.md
+++ b/1209/9001/index.md
@@ -1,0 +1,15 @@
+---
+layout: pid
+title: North Star Integrator
+owner: Combine Reality
+license: cc-bt-sa-4.0
+site: combinereality.org
+source: https://github.com/CombineReality/North-Star-Integrator ; https://github.com/CombineReality/ArduinoCore-avr
+---
+
+The North Star Integrator is a purpose-built USB hub 
+with on-board mass storage and an Atmega 32u4 running 
+the Arduino Caterina bootloader. It is intended for 
+use in Project North Star open source AR headsets and 
+derivative devices.
+

--- a/1209/9001/index.md
+++ b/1209/9001/index.md
@@ -4,7 +4,8 @@ title: North Star Integrator
 owner: Combine Reality
 license: cc-bt-sa-4.0
 site: combinereality.org
-source: https://github.com/CombineReality/North-Star-Integrator ; https://github.com/CombineReality/ArduinoCore-avr
+source: https://github.com/CombineReality/North-Star-Integrator ; 
+Based on lilyPadUSB-caterina, for use with the Combine Reality North Star Integrator board: https://github.com/CombineReality/ArduinoCore-avr
 ---
 
 The North Star Integrator is a purpose-built USB hub 

--- a/org/CombineReality/index.md
+++ b/org/CombineReality/index.md
@@ -1,7 +1,8 @@
 ---
 layout: org
 title: CombineReality
-site: https://combinereality.com/
+site: https://combinereality.com/ ; 
+product page: https://www.smart-prototyping.com/AR-VR-MR-XR/North-Star-Deck-X-Specific-Electronics
 ---
 The North Star Integrator is a purpose-built USB hub 
 with on-board mass storage and an Atmega 32u4 running 

--- a/org/CombineReality/index.md
+++ b/org/CombineReality/index.md
@@ -1,0 +1,10 @@
+---
+layout: org
+title: CombineReality
+site: https://combinereality.com/
+---
+The North Star Integrator is a purpose-built USB hub 
+with on-board mass storage and an Atmega 32u4 running 
+the Arduino Caterina bootloader. It is intended for 
+use in Project North Star open source AR headsets and 
+derivative devices.


### PR DESCRIPTION
**As suggested, changed name of owner in 9001.md and source link.

The North Star Integrator is a purpose-built USB hub 
with on-board mass storage and an Atmega 32u4 running 
the Arduino Caterina bootloader. It is intended for 
use in Project North Star open source AR headsets and 
derivative devices.
