### PR TITLE
Fix MJS2020 (1209/3320) board page

### DIFF
--- a/1209/3320/index.md
+++ b/1209/3320/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: MJS2020: Meetjestad sensor station 2020
+title: "MJS2020: Meetjestad sensor station 2020"
 owner: Meetjestad
 license: CERN-OHL-W
 site: https://www.meetjestad.net


### PR DESCRIPTION
This used a colon in the title, which breaks parsing of the frontmatter
block. This causes the board to be omitted from the pid list and the
board page to only show the extended description, none of the defined
fields.

Adding quotes around the title fixes this.