### PR TITLE
Request PID for STM32 Blue pill Serial Monster

### DIFF
--- a/1209/FFFE/index.md
+++ b/1209/FFFE/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: STM32 Blue Pill Serial Monster
+owner: r2axz
+license: MIT
+site: https://github.com/r2axz
+source: https://github.com/r2axz/bluepill-serial-monster
+---

--- a/org/r2axz/index.md
+++ b/org/r2axz/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Kirill Kotyagin (R2AXZ)
+site: https://github.com/r2axz
+---
+Software developer, ham radio operator, and electronics enthusiast.


### PR DESCRIPTION
Hi,

please assign PID for my open source STM32 firmware project.

STM32 Blue Pill Serial Monster is a 3-port USB-to-Serial adapter firmware project for STM32 Blue Pill (STM32F103C8T6). The firmware supports 3 independent UART ports, RTS/CTS, DSR/DTR/DCD, 7/8 bits word length, parity, 1, 1.5, and 2 stop bits, works with built-in drivers on Win/OS X/Linux, DMA RX/TX. Open source, MIT license.

Kind regards,
Kirill.
