### PR TITLE
Requested PIDs 0xBABA and 0xDEDA

### DIFF
--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -1,0 +1,20 @@
+---
+layout: pid
+title: Famicom Cartridge Dumper/Writer
+owner: Alexey 'Cluster' Avdyukhin
+license: GPLv3
+site: https://github.com/ClusterM/famicom-dumper
+source: https://github.com/ClusterM/famicom-dumper
+---
+This is simple dumper/writer for Famicom cartridges.
+
+![Dumper](https://github.com/ClusterM/famicom-dumper/raw/master/images/dumper.jpg)
+
+You can use it to:
+* Dump cartridges, so you can play copy of your cartridge on emulator
+* Read/write battery backed saves, so you can continue your saved game on emulator/console
+* Write special cartridges like [COOLGIRL](https://github.com/ClusterM/coolgirl-famicom-multicard)
+* Rewrite ultracheap chinese COOLBOY cartridges. Soldering required but it's very simple.
+* Test your cartridges
+* Some reverse engineering
+* Anything else that requires Famicom bus simulation

--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Famicom Cartridge Dumper/Writer
-owner: Alexey 'Cluster' Avdyukhin
+owner: ClusterM
 license: GPLv3
 site: https://github.com/ClusterM/famicom-dumper
 source: https://github.com/ClusterM/famicom-dumper

--- a/1209/DEDA/index.md
+++ b/1209/DEDA/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Famicom Cartridge Dumper/Writer
+owner: Alexey 'Cluster' Avdyukhin
+license: GPLv3
+site: https://github.com/ClusterM/nessmd2usb
+source: https://github.com/ClusterM/nessmd2usb
+---
+Famiclone and Sega Mega Drive controller to USB adapters.
+
+![NESSMD2USB](https://github.com/ClusterM/nessmd2usb/raw/master/images/photo.jpg)

--- a/1209/DEDA/index.md
+++ b/1209/DEDA/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Famicom Cartridge Dumper/Writer
-owner: Alexey 'Cluster' Avdyukhin
+owner: ClusterM
 license: GPLv3
 site: https://github.com/ClusterM/nessmd2usb
 source: https://github.com/ClusterM/nessmd2usb


### PR DESCRIPTION
Requested PID 0xBABA for Famicom Dumper/Writer: https://github.com/ClusterM/famicom-dumper
Requested PID 0xDEDA for Famiclone and Sega Mega Drive to USB adapters: https://github.com/ClusterM/nessmd2usb