### PR TITLE
Requested PIDs 0xBABA and 0xDEDA

### DIFF
--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -1,0 +1,20 @@
+---
+layout: pid
+title: Famicom Cartridge Dumper/Writer
+owner: Cluster
+license: GPLv3
+site: https://github.com/ClusterM/famicom-dumper
+source: https://github.com/ClusterM/famicom-dumper
+---
+This is simple dumper/writer for Famicom cartridges.
+
+![Dumper](https://github.com/ClusterM/famicom-dumper/raw/master/images/dumper.jpg)
+
+You can use it to:
+* Dump cartridges, so you can play copy of your cartridge on emulator
+* Read/write battery backed saves, so you can continue your saved game on emulator/console
+* Write special cartridges like [COOLGIRL](https://github.com/ClusterM/coolgirl-famicom-multicard)
+* Rewrite ultracheap chinese COOLBOY cartridges. Soldering required but it's very simple.
+* Test your cartridges
+* Some reverse engineering
+* Anything else that requires Famicom bus simulation

--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -2,19 +2,23 @@
 layout: pid
 title: Famicom Cartridge Dumper/Writer
 owner: Cluster
-license: MIT
-site: https://github.com/ClusterM/famicom-dumper
-source: https://github.com/ClusterM/famicom-dumper
+license: GPLv3
+site: https://github.com/ClusterM/famicom-dumper-writer
+source: https://github.com/ClusterM/famicom-dumper-writer
 ---
-This is simple dumper/writer for Famicom cartridges.
+This is simple dumper/writer for Famicom cartridges and Famicom Disc System cards. This version is much faster compared to
+the [old one](https://github.com/ClusterM/famicom-dumper). It's using very accurate M2 cycle simulation and usinc FSMC
+(Flexible Static Memory Controller) to access PRG and CHR memory. FSMC is precisely synchronized with the M2 clock signal
+using CPLD chip. Also new version uses fast on-chip USB controller instead of slow FT232 USB-UART converter.
 
-![Dumper](https://github.com/ClusterM/famicom-dumper/raw/master/images/dumper.jpg)
+![Dumper](https://github.com/ClusterM/famicom-dumper-writer/raw/main/photos/dumper.jpg)
 
 You can use it to:
 * Dump cartridges, so you can play copy of your cartridge on emulator
 * Read/write battery backed saves, so you can continue your saved game on emulator/console
 * Write special cartridges like [COOLGIRL](https://github.com/ClusterM/coolgirl-famicom-multicard)
-* Rewrite ultracheap chinese COOLBOY cartridges. Soldering required but it's very simple.
+* Rewrite ultracheap chinese COOLBOY cartridges. Soldering is required for old versions but it's very simple. New versions can be rewrited without soldering
 * Test your cartridges
+* Read and frite Famicom Disk System cards using FDS drive with RAM adapter
 * Some reverse engineering
 * Anything else that requires Famicom bus simulation

--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -17,7 +17,7 @@ You can use it to:
 * Dump cartridges, so you can play copy of your cartridge on emulator
 * Read/write battery backed saves, so you can continue your saved game on emulator/console
 * Write special cartridges like [COOLGIRL](https://github.com/ClusterM/coolgirl-famicom-multicard)
-* Rewrite ultracheap chinese COOLBOY cartridges. Soldering is required for old versions but it's very simple. New versions can be rewrited without soldering
+* Rewrite ultracheap chinese COOLBOY cartridges. Soldering is required for old versions but it's very simple. New versions can be rewritten without soldering
 * Test your cartridges
 * Read and frite Famicom Disk System cards using FDS drive with RAM adapter
 * Some reverse engineering

--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -6,19 +6,17 @@ license: GPLv3
 site: https://github.com/ClusterM/famicom-dumper-writer
 source: https://github.com/ClusterM/famicom-dumper-writer
 ---
-This is simple dumper/writer for Famicom cartridges and Famicom Disc System cards. This version is much faster compared to
-the [old one](https://github.com/ClusterM/famicom-dumper). It's using very accurate M2 cycle simulation and usinc FSMC
-(Flexible Static Memory Controller) to access PRG and CHR memory. FSMC is precisely synchronized with the M2 clock signal
-using CPLD chip. Also new version uses fast on-chip USB controller instead of slow FT232 USB-UART converter.
+This is a simple dumper/writer for Famicom cartridges and Famicom Disc System cards. This version is much faster compared to the [old one](https://github.com/ClusterM/famicom-dumper). It's using a very accurate M2 cycle simulation and FSMC (Flexible Static Memory Controller) to access PRG and CHR memory. FSMC is precisely synchronized with the M2 clock signal using a CPLD chip. The new version is also using a fast on-chip USB controller instead of a slow FT232 USB-UART converter.
 
 ![Dumper](https://github.com/ClusterM/famicom-dumper-writer/raw/main/photos/dumper.jpg)
 
 You can use it to:
-* Dump cartridges, so you can play copy of your cartridge on emulator
-* Read/write battery backed saves, so you can continue your saved game on emulator/console
-* Write special cartridges like [COOLGIRL](https://github.com/ClusterM/coolgirl-famicom-multicard)
-* Rewrite ultracheap chinese COOLBOY cartridges. Soldering is required for old versions but it's very simple. New versions can be rewritten without soldering
-* Test your cartridges
-* Read and frite Famicom Disk System cards using FDS drive with RAM adapter
-* Some reverse engineering
-* Anything else that requires Famicom bus simulation
+
+* Dump cartridges, so you can play copy of your cartridge on emulator.
+* Read/write battery backed saves, so that you can continue your saved game on emulator/console.
+* Write special cartridges like [COOLGIRL](https://github.com/ClusterM/coolgirl-famicom-multicard).
+* Rewrite ultracheap chinese COOLBOY cartridges. Soldering is required to work with old versions but it's very simple. New versions can be rewritten without soldering.
+* Test your cartridges.
+* Read and frite Famicom Disk System cards using FDS drive with the RAM adapter.
+* Some reverse engineering.
+* Anything else that requires Famicom bus simulation.

--- a/1209/BABA/index.md
+++ b/1209/BABA/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: Famicom Cartridge Dumper/Writer
 owner: Cluster
-license: GPLv3
+license: MIT
 site: https://github.com/ClusterM/famicom-dumper
 source: https://github.com/ClusterM/famicom-dumper
 ---

--- a/1209/DEDA/index.md
+++ b/1209/DEDA/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Famiclone and Sega Mega Drive controller to USB adapters
+owner: Cluster
+license: GPLv3
+site: https://github.com/ClusterM/nessmd2usb
+source: https://github.com/ClusterM/nessmd2usb
+---
+Famiclone and Sega Mega Drive controller to USB adapters.
+
+![NESSMD2USB](https://github.com/ClusterM/nessmd2usb/raw/master/images/photo.jpg)

--- a/org/Cluster/index.md
+++ b/org/Cluster/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Alexey 'Cluster' Avdyukhin
+---
+[Alexey 'Cluster' Avdyukhin](http://github.com/ClusterM/). Russian hardware and software developer.


### PR DESCRIPTION
PID 0xBABA for Famicom Cartridge Dumper/Writer: https://github.com/ClusterM/famicom-dumper-writer
PID 0xDEDA for Famiclone and Sega Mega Drive controller to USB: https://github.com/ClusterM/nessmd2usb