### PR TITLE
Request PID C55D for ch55xduino hid device

### DIFF
--- a/1209/C55D/index.md
+++ b/1209/C55D/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: ch55xduino for HID devices
-owner: Think Create
+owner: ThinkCreate
 license: LGPL
 site: https://github.com/DeqingSun/ch55xduino
 source: https://github.com/DeqingSun/ch55xduino

--- a/1209/C55D/index.md
+++ b/1209/C55D/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: ch55xduino for HID devices
+owner: Think Create
+license: LGPL
+site: https://github.com/DeqingSun/ch55xduino
+source: https://github.com/DeqingSun/ch55xduino
+---
+ch55xduino is an Arduino-like programming API for the CH55X, a family of low-cost MCS51 USB MCU. The project tries to remove the difficulty of setting up a compiling environment. 


### PR DESCRIPTION
ch55xduino is a fork of open-sourced project sduino with LGPL license. It has been iterated for many versions.