### PR TITLE
Request PID 5C00

### DIFF
--- a/1209/5C00/index.md
+++ b/1209/5C00/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: c-pro-micro
+owner: Guri-Tech
+license: CC BY-SA 3.0
+site: https://github.com/zgtk-guri/c-pro-micro
+source: https://github.com/zgtk-guri/c-pro-micro
+---

--- a/org/Guri-Tech/index.md
+++ b/org/Guri-Tech/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Guri-Tech
+site: https://guri-tech.booth.pm/
+---
+Guri-Tech develops open-source usb mcu board with type-c for opensource keyboard


### PR DESCRIPTION
Request 1209:5C00 for a Pro micro compatible mcu board with a USB Type-C receptacle.
https://github.com/zgtk-guri/c-pro-micro
VID/PID will be used with Catalina bootloader.