### PR TITLE
PID request for Studio H Software - Wireless Preset Manager

### DIFF
--- a/1209/FBA0/index.md
+++ b/1209/FBA0/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Wireless Preset Manager
+owner: studiohsoftware
+license: GPLv3
+site: http://studiohsoftware.com/modular
+source: https://github.com/studiohsoftware/2WIRELESS
+---
+

--- a/org/studiohsoftware/index.md
+++ b/org/studiohsoftware/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: studiohsoftware
+site: https://studiohsoftware.com/
+---
+Studio H Software is a software and hardware company specializing in modular synthesizer modules.


### PR DESCRIPTION
This device presents a Wifi and USB interface
for Buchla 200e modular synthesizers.

Studio H Software Open source project here
https://github.com/studiohsoftware/2WIRELESS

The WPM optionally runs as a USB MIDI device
and it would be helpful to musicians to see
a meaningful device name.