### PR TITLE
KoBussLLC PID BA00 and BA01 for Grabert and Squash Mechanical Keyboards

### DIFF
--- a/1209/BA00/index.md
+++ b/1209/BA00/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Squash
-owner: KoBuss LLC
+owner: kobussllc
 license: CC BY-NC 4.0
 site: https://github.com/KoBussLLC
 source: https://github.com/KoBussLLC/squash-hardware

--- a/1209/BA00/index.md
+++ b/1209/BA00/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: Squash
+owner: KoBuss LLC
+license: CC BY-NC 4.0
+site: https://github.com/KoBussLLC
+source: https://github.com/KoBussLLC/squash-hardware
+---
+Squash is a 40% mechanical keyboard based on a acrylic case, POM switch plate, and STM32F072 based micro-controller. Squash's hardware is open-source using KiCad, FreeCAD, and QMK firmware.
+
+The keyboard features an OLED screen, rotary knob, sandwich mount case, and layout options. 
+
+See the [KoBussLLC QMK fork](https://github.com/KoBussLLC/qmk_firmware/tree/kobuss/keyboards/kobuss/squash) for firmware source.

--- a/1209/BA01/index.md
+++ b/1209/BA01/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Grabert
-owner: KoBuss LLC
+owner: kobussllc
 license: CC BY-NC 4.0
 site: https://github.com/KoBussLLC
 source: https://github.com/KoBussLLC/grabert-hardware

--- a/1209/BA01/index.md
+++ b/1209/BA01/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: Grabert
+owner: KoBuss LLC
+license: CC BY-NC 4.0
+site: https://github.com/KoBussLLC
+source: https://github.com/KoBussLLC/grabert-hardware
+---
+Grabert is a 60% mechanical keyboard based on a acrylic case, POM switch plate, and STM32F072 based micro-controller. Grabert's hardware is open-source using KiCad, FreeCAD, and QMK firmware.
+
+The keyboard features an OLED screen, rotary knob, sandwich mount case, and 4 layout options. 
+
+See the [KoBussLLC QMK fork](https://github.com/KoBussLLC/qmk_firmware/tree/kobuss/keyboards/kobuss/grabert) for firmware source.

--- a/org/kobussllc/index.md
+++ b/org/kobussllc/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: KoBuss LLC
+site: https://github.com/KoBussLLC
+---
+KoBuss LLC is a mechanical keyboard and accessories company looking to provide available and accessible open-source products and education


### PR DESCRIPTION
Requesting BA00 and BA01 for two open-source mechanical keyboards. The hardware is open-source using KiCad and FreeCAD, and the firmware is enabled by the open-source project QMK. 