### PR TITLE
Generation of pid request for Orbtrace

### DIFF
--- a/1209/3443
+++ b/1209/3443
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Orbtrace
+owner: Orbcode
+license: BSD
+site: https://github.com/orbcode
+source: https://github.com/orbcode/orbuculum/tree/Devel/orbtrace
+---

--- a/org/Orbcode/index.md
+++ b/org/Orbcode/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Orbcode
+site: https://github.com/orbcode
+---
+Dedicated to create Open debug instrumentation for everyone to use.


### PR DESCRIPTION
Hi there,

We are working on an (Open) USB-based TRACE sniffer for CORTEX-M. It is under a BSD licence. The hardware is based on an ECP5 FPGA and USB-HS (eventually USB-SS, but that's step 2). It would be appreciated if we can get a PID for this device. Full bitware and supporting software is at the links provided in the request.

Thanks in advance

DAVE
