### PR TITLE
Request PIDs for Silicognition LLC M4-Shim

### DIFF
--- a/1209/F500/index.md
+++ b/1209/F500/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: M4-Shim
+owner: silicognition
+license: CC-BY-SA
+site: https://github.com/xorbit/M4-Shim
+source: https://github.com/xorbit/M4-Shim
+---
+M4-Shim for PoE-FeatherWing, functionally equivalent to Feather M4 Express
+but physically shaped to allow mounting on top of the PoE-FeatherWing.

--- a/1209/F501/index.md
+++ b/1209/F501/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: M4-Shim Bootloader
+owner: silicognition
+license: CC-BY-SA
+site: https://github.com/xorbit/M4-Shim
+source: https://github.com/xorbit/M4-Shim
+---
+Bootloader for M4-Shim

--- a/org/silicognition/index.md
+++ b/org/silicognition/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Silicognition LLC
+site: http://silicognition.com
+---
+Silicognition LLC is an engineering company that focuses on embedded systems,
+IoT and practival power solutions to ease deployment of such systems.


### PR DESCRIPTION
Two PIDs, one for main firmware (CircuitPython) and one for
bootloader (UF2).