### PR TITLE
RIOT: Allocate 7D02 for devices executing the shipped bootloader

### DIFF
--- a/1209/7D02/index.md
+++ b/1209/7D02/index.md
@@ -1,0 +1,15 @@
+---
+layout: pid
+title: riotboot DFU Bootloader
+owner: RIOT
+license: any
+site: http://riot-os.org/
+source: https://github.com/RIOT-OS/RIOT
+---
+This PID describes devices that run RIOT's DFU-based riotboot bootloader.
+
+It is not related to any particular hardware;
+which concrete board it is used for is indicated in the DFU details.
+
+Note that devices that use this ID would usually come up with [1209/7D00](https://pid.codes/1209/7D00/);
+only when sent to their bootloader mode, they reboot and offer this ID.


### PR DESCRIPTION
This is an extension to the previously allocated pairs 1209/7D00 and /7D01.

As anticipated back then, there is now a USB bootloader, which it makes sense to distinguish from the regular applications. This PR is allocating 7D02 for that purpose.