### PR TITLE
1209/7D02: License correction

### DIFF
--- a/1209/7D02/index.md
+++ b/1209/7D02/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: riotboot DFU Bootloader
 owner: RIOT
-license: any
+license: LGPL-2.1
 site: http://riot-os.org/
 source: https://github.com/RIOT-OS/RIOT
 ---


### PR DESCRIPTION
I made a mistake when building 7D02 in #618 copying from 7D01; this fixes the oversight.

("any" applies to general applications built on RIOT; the code only applies to the DFU bootloader shipped with the OS, which is LGPL).