### PR TITLE
Register hswaw (Warsaw Hackerspace) and 1209:2137 (Web I2C Programmer)

### DIFF
--- a/1209/2137/index.md
+++ b/1209/2137/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: Web I2C Programmer
+owner: hswaw
+license: ISC
+site: https://hackdoc.hackerspace.pl/dc/hbj11/flasher/bluepill/
+source: https://cs.hackerspace.pl/hscloud/-/tree/dc/hbj11/flasher/bluepill
+---
+
+A USB-driven I2C programmer based on an STM32F103C8T6 on a 'Bluepill' devboard. Accessible from a [WebUSB based interface](https://hackdoc.hackerspace.pl/dc/hbj11/flasher/web/README.md).
+
+NOTE: This project is contained within a monorepo ([hscloud](https://cs.hackerspace.pl/hscloud)) which is licensed under the ISC license and other compatible open source licenses. See [COPYING](https://cs.hackerspace.pl/hscloud/-/blob/COPYING) for more information.

--- a/org/hswaw/index.md
+++ b/org/hswaw/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Warsaw Hackersoace
+site: https://hackerspace.pl/
+---
+A Hackerspace in Warsaw, Poland. Also home of the [bgp.wtf](https://bgp.wtf/) ISP.


### PR DESCRIPTION
Requesting organization for Warsaw Hackerspace and a PID for a WebUSB-enabled I2C programmer. Thanks!

For orga verification, you can email {q3k,staff,postmaster}@hackerspace.pl if needed.

Note: the source code linked is a subdirectory of a monorepo, with licensing information contained at its root.