### PR TITLE
Add org/Accelerando and a PID proposal for Accelerando Redsoil

### DIFF
--- a/1209/ACC1/index.md
+++ b/1209/ACC1/index.md
@@ -1,0 +1,19 @@
+---
+layout: pid
+title: Redsoil
+owner: Accelerando
+license: 3-Clause BSD
+site: https://accelerando.com.au/learn/
+source: https://github.com/accelerando-consulting/accelerando_redsoil
+---
+The [Accelerando Redsoil](https://github.com/accelerando-consulting/accelerando_redsoil)
+is a breakout board for the eByte E73 module with nrf52840 CPU.
+
+Redsoil provides a breadboard-friendly platform that is
+perhaps the simplest possible board that is fully CircuitPython
+compliant.
+
+The Redsoil also runs Arduino, and Zephyr OS.
+
+The Redsoil was created by Accelerando in order to provide a platform
+for rapid prototyping of extremely low-cost IoT solutions.

--- a/org/Accelerando/index.md
+++ b/org/Accelerando/index.md
@@ -1,0 +1,23 @@
+---
+layout: org
+title: Accelerando
+site: http://accelerando.com.au/
+---
+Accelerando is an IoT consulting firm that operates a tech incubator
+and makerspace in Brisbane Australia.
+
+Accelerando provides research, design and implementation of IoT, Smart
+City and Robotics projects.  Accelerando assist startups by providing them
+with advice and a space to operate (some startup services on a pro
+bono or discount basis).   Accelerando also serves commericial and
+government clients.
+
+The core technologies that serve many of Accelerando's clients are
+open source, Accelerando we believes that consultants should leave
+organisations in control of their destiny, not addicted to further
+consulting.
+
+You can find Accelerando's open source projects at
+[our github](https://github.com/accelerando-consulting/),
+and learn more from [our blog](http://accelerando.com.au/news/) and
+[our learning portal](http://accelerando.com.au/learn/).


### PR DESCRIPTION
Accelerando Redsoil is a low-parts breakout board for the nrf52840.  It can run Micropython, Zephyr or Arduino.