### PR TITLE
SoloKeys Solo 2 device/bootloader PIDs

### DIFF
--- a/1209/B000/index.md
+++ b/1209/B000/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Solo 2 Bootloader
+owner: SoloKeys
+license: Apache-2.0 OR MIT
+site: https://solokeys.com/
+source: https://github.com/solokeys/solo2/
+---

--- a/1209/BEEE/index.md
+++ b/1209/BEEE/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Solo 2
+owner: SoloKeys
+license: Apache-2.0 OR MIT
+site: https://solokeys.com/
+source: https://github.com/solokeys/solo2/
+---

--- a/org/SoloKeys/index.md
+++ b/org/SoloKeys/index.md
@@ -3,18 +3,18 @@ layout: org
 title: SoloKeys
 site: https://solokeys.com
 ---
-Open source security tokens.
 
+Open source USB/NFC security devices.
 
 ### Licenses
-All our products use permissive licenses:
 
-- Software: dual Apache-2.0/MIT
-- Hardware: dual CERN/CC BY-SA
-- Documentation: CC BY-SA
+- Software: Apache-2.0 or MIT (dual)
+- Hardware: CERN-OHL-S-2.0
+- Documentation: CC-BY-SA-4.0
 
 ### Certifications
-Existing products are OSHWA certified:
 
 - Solo: <https://certification.oshwa.org/us000154.html>
 - Solo Tap: <https://certification.oshwa.org/us000155.html>
+- Somu: <https://certification.oshwa.org/us000168.html>
+


### PR DESCRIPTION
Hi!

We'd like to use 0x1209 PIDs for the release of our new 2nd gen security device, the "Solo 2".

- 1209:BEEE for the device in main/authenticator mode
- 1209:B000 for the bootloader mode

Thanks!

HW is adjacent to linked repo: https://github.com/solokeys/solo2-hw