### PR TITLE
Add CP Sapling Rev B 

### DIFF
--- a/1209/4DDE/index.md
+++ b/1209/4DDE/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: CP Sapling Development Board Revision B
+title: CP Sapling Development Board w/ SPI Flash
 owner: OakDevelopmentTechnologies
 license: MIT
 site: https://github.com/skerr92/odt-dev-boards

--- a/1209/4DDE/index.md
+++ b/1209/4DDE/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: CP Sapling Development Board w/ SPI Flash
+title: CP Sapling Development Board Revision B
 owner: OakDevelopmentTechnologies
 license: MIT
 site: https://github.com/skerr92/odt-dev-boards

--- a/1209/4DDF/index.md
+++ b/1209/4DDF/index.md
@@ -3,6 +3,6 @@ layout: pid
 title: CP Sapling Development Board Revision B
 owner: OakDevelopmentTechnologies
 license: MIT
-site: https://github.com/skerr92/odt-dev-boards
-source: https://github.com/skerr92/odt-dev-boards
+site: https://github.com/skerr92/odt-dev-boards/tree/master/boards/CP_Sapling_Rev_b
+source: https://github.com/skerr92/circuitpython/tree/add-cp-sapling-rev-b/ports/atmel-samd/boards/cp_sapling_m0_revb
 ---

--- a/1209/4DDF/index.md
+++ b/1209/4DDF/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: CP Sapling Development Board Revision B
+owner: OakDevelopmentTechnologies
+license: MIT
+site: https://github.com/skerr92/odt-dev-boards
+source: https://github.com/skerr92/odt-dev-boards
+---


### PR DESCRIPTION
This is to add a newer version of the CP Sapling. 

Changes over previous versions:
- More pins broken out to headers
- dedicated SPI Flash lines separate from SPI peripheral lines