### PR TITLE
Add PID 0x4040 for PicoHX FPGA programmer

### DIFF
--- a/1209/4040/index.md
+++ b/1209/4040/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: PicoHX iCE40 SPI programmer
+owner: drr
+license: MIT, CERN-OHL-W-2.0
+site: https://github.com/dan-rodrigues/pico-hx
+source: https://github.com/dan-rodrigues/pico-hx
+---
+

--- a/org/drr/index.md
+++ b/org/drr/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Dan Rodrigues (@drr)
+site: https://github.com/dan-rodrigues
+---
+Open source software and hardware enthusiast.
+


### PR DESCRIPTION
This PR adds the `drr` org and the PID mentioned in the title.

The PID is for [this PCB](https://github.com/dan-rodrigues/pico-hx) where an RP2040 implements a USB device that can program an iCE40 FPGA using a bitstream sent by the host.

