### PR TITLE
Bootloader pid for orbtrace

### DIFF
--- a/1209/3442/index.md
+++ b/1209/3442/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Orbtrace-boot
+owner: Orbcode
+license: BSD
+site: https://github.com/orbcode
+source: https://github.com/orbcode/orbtrace
+---
+Bootloader for Open CMSIS-DAP + Parallel trace interface for CORTEX-M

--- a/1209/3443
+++ b/1209/3443
@@ -1,8 +1,0 @@
----
-layout: pid
-title: Orbtrace
-owner: Orbcode
-license: BSD
-site: https://github.com/orbcode
-source: https://github.com/orbcode/orbuculum/tree/Devel/orbtrace
----

--- a/1209/3443/index.md
+++ b/1209/3443/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Orbtrace
+owner: Orbcode
+license: BSD
+site: https://github.com/orbcode
+source: https://github.com/orbcode/orbtrace
+---
+Open CMSIS-DAP + Parallel trace interface for CORTEX-M


### PR DESCRIPTION
For Orbtrace we need a separate PID for bootloader update mode...I hope that is OK.  I've also taken the opportunity to clean up the mess I made of requesting the original Orbtrace PID, and also moving the URL for that as we've split it into a separate project away from Orbuculum now, to keep things a bit cleaner.

DAVE
