### PR TITLE
PID for Tron Guy Labs M122/3270 USB keyboard

### DIFF
--- a/1209/3270/index.md
+++ b/1209/3270/index.md
@@ -4,7 +4,8 @@ title: M122/3270 USB keyboard
 owner: TronGuyLabs
 license: GPL 2
 site: https://github.com/jmaynard/qmk_firmware
-source: https://github.com/jmaynard/qmk_firmware
+source: https://github.com/jmaynard/qmk_firmware/tree/tronguylabs-keyboards/keyboards/tronguylabs/m122_3270
+PCBs: https://github.com/jmaynard/tronguylabs-m122-blackpill
 ---
 The M122 3270 USB keyboard is an adaptation of the classic IBM Model M
 122-key 3270-layout keyboard to USB, switchable between acting like a

--- a/1209/3270/index.md
+++ b/1209/3270/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: M122 3270 USB keyboard
+title: M122/3270 USB keyboard
 owner: TronGuyLabs
 license: GPL 2
 site: https://github.com/jmaynard/qmk_firmware

--- a/1209/3270/index.md
+++ b/1209/3270/index.md
@@ -4,7 +4,7 @@ title: M122/3270 USB keyboard
 owner: TronGuyLabs
 license: GPL 2
 site: https://github.com/jmaynard/qmk_firmware
-source: https://github.com/jmaynard/qmk_firmware/tree/tronguylabs-keyboards/keyboards/tronguylabs/m122_3270
+source: https://github.com/qmk/qmk_firmware/tree/master/keyboards/tronguylabs/m122_3270
 PCBs: https://github.com/jmaynard/tronguylabs-m122-blackpill
 ---
 The M122 3270 USB keyboard is an adaptation of the classic IBM Model M

--- a/1209/3270/index.md
+++ b/1209/3270/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: M122 3270 USB keyboard
+owner: TronGuyLabs
+license: GPL 2
+site: https://github.com/jmaynard/qmk_firmware
+source: https://github.com/jmaynard/qmk_firmware
+---
+The M122 3270 USB keyboard is an adaptation of the classic IBM Model M
+122-key 3270-layout keyboard to USB, switchable between acting like a
+standard PC keyboard and a 3270 terminal keyboard with actions faithful
+to the key legends.

--- a/org/TronGuyLabs/index.md
+++ b/org/TronGuyLabs/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: Tron Guy Labs
+---
+Projects developed by Jay Maynard, the Tron Guy.


### PR DESCRIPTION
Requesting PID 1209/3270 for a controller board for the IBM Model M 122-key keyboard. This isn't a converter, but replaces the internal controller entirely. It uses the open-source QMK firmware. My code is in the QMK repository I linked, in the keyboards/tronguylabs directory. The schematic and Gerber files for a carrier board that connects the matrix connectors to the BlackPill MCU can be found at https://github.com/jmaynard/tronguylabs-m122-blackpill ; those files are licensed under the Solderpad Hardware License v2.1.