### PR TITLE
Add PurkkaLabs SecretKey as PID 1209:5AFE and 5AFD

### DIFF
--- a/1209/5AFD/index.md
+++ b/1209/5AFD/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SecretKey Bootloader
+owner: PurkkaLabs
+license: CERN-OHL-W 2.0 and MIT
+site: https://gitlab.com/PurkkaKoodari/secretkey
+source: https://gitlab.com/PurkkaKoodari/secretkey
+---
+The SecretKey is a USB key that acts as a FIDO2 authenticator and secret storage device. This PID is for the firmware upgrade bootloader.

--- a/1209/5AFE/index.md
+++ b/1209/5AFE/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SecretKey
+owner: PurkkaLabs
+license: CERN-OHL-W 2.0 and MIT
+site: https://gitlab.com/PurkkaKoodari/secretkey
+source: https://gitlab.com/PurkkaKoodari/secretkey
+---
+The SecretKey is a USB key that acts as a FIDO2 authenticator and secret storage device.

--- a/org/PurkkaLabs/index.md
+++ b/org/PurkkaLabs/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: PurkkaLabs
+site: https://purkka.codes/
+---
+I'm PurkkaKoodari, a hobbyist open-source software and hardware hacker. PurkkaLabs is my fictional organization that looks cleaner in `lsusb`.


### PR DESCRIPTION
[SecretKey](https://gitlab.com/PurkkaKoodari/secretkey) is (will be) a USB key that acts as a FIDO2 authenticator and secret storage device.

Requesting PID 5AFE for regular use, and a separate PID 5AFD for the bootloader as that will use a different interface.

The current hardware design is already in the linked repo and licensed under CERN-OHL-W v2.

The software is vaporware for now, but will be based on [Solo](https://github.com/solokeys/solo)'s source code and licensed under MIT. (I'm waiting for some chips to arrive so I can start properly developing it - the availability of parts isn't exactly ideal right now.)