### PR TITLE
PID allocation request for bad_alloc's dragonBoot

### DIFF
--- a/1209/BADB/index.md
+++ b/1209/BADB/index.md
@@ -1,0 +1,21 @@
+---
+layout: pid
+title: dragonBoot
+owner: bad_alloc
+license: BSD-3-Clause
+site: https://github.com/bad-alloc-heavy-industries/dragonBoot
+source: https://github.com/bad-alloc-heavy-industries/dragonBoot
+---
+To support bad_alloc USB products, and support the need to update firmware on
+them without expensive JTAG adaptors, the idea of a common general-purpose DFU
+bootloader was devised - dragonBoot
+
+With MXKeyboard and SPIFlashProgrammer both sporting similar USB stacks with the
+intention to one day make them both use the same stack, dragonUSB was born.
+
+dragonUSB with appropriate non-target-specific drivers can efficiently implement
+USB on a variety of targets with excellent type-safety and good support for
+descriptors that aren't just byte blobs.
+
+dragonBoot uses dragonUSB to target both platforms and uses dragonUSB's DFU driver
+to implement dfu-util friendly DFU.


### PR DESCRIPTION
Prefered PID for dragonBoot is BADB

The project is licensed under BSD-3-Clause, as are all projects on which dragonBoot depends (dragonUSB, dragonTI, substrate).

License for dragonBoot: Software