### PR TITLE
Pi-KVM organization and IDs

### DIFF
--- a/1209/EDA1/index.md
+++ b/1209/EDA1/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Pi-KVM Composite Device
+owner: Pi-KVM
+license: GPLv3
+site: https://pikvm.org
+source: https://github.com/pikvm/pikvm
+---
+Open and cheap DIY IP-KVM based on Raspberry Pi.
+
+This device can combine HID, Mass Storage, Ethernet-over-USB, and so on.

--- a/1209/EDA2/index.md
+++ b/1209/EDA2/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Pi-KVM HID
+owner: Pi-KVM
+license: GPLv3
+site: https://pikvm.org
+source: https://github.com/pikvm/pikvm
+---
+Open and cheap DIY IP-KVM based on Raspberry Pi.
+
+Dedicated hardware HID.

--- a/org/Pi-KVM/index.md
+++ b/org/Pi-KVM/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Pi-KVM
+site: https://pikvm.org
+---
+Open and cheap DIY IP-KVM based on Raspberry Pi


### PR DESCRIPTION
Hi! Pi-KVM is a project to create an open source KVM-over-IP based on Raspberry Pi. All software is distributed under the GPLv3 license, the basic schematic technology is also open.

I'm asking you to allocate two identifiers for different USB emulation devices. They will be used to make it easier for system administrators to distinguish them from generic Arduino and other OTG devices.

https://github.com/pikvm/pikvm