### PR TITLE
Add Rookie Drive in device mode as 1209/3434

### DIFF
--- a/1209/3434/index.md
+++ b/1209/3434/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Rookie Drive in device mode
+owner: Konamiman
+license: MIT (software), GPL 2 (hardware)
+site: https://github.com/Konamiman/NestorDevice/
+source: https://github.com/S0urceror/MSX-USB/
+---
+Rookie Drive is a cartridge for MSX computers featuring a CH376 chip and an USB-A port. Originally the cartridge was designed to work as an USB host, but the CH376 can be configured and used as a device as well with the appropriate software. MSX-USB is an open source clone of Rookie Drive.

--- a/org/Konamiman/index.md
+++ b/org/Konamiman/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Konamiman
+site: http://www.konamiman.com/
+---
+I'm just a geek developing software for MSX computers in my free time, often in collaboration with other geeks who develop hardware.
+


### PR DESCRIPTION
[Rookie Drive](http://rookiedrive.com/en/) is a cartridge for MSX computers featuring a CH376 chip and an USB-A port. Originally the cartridge was designed to work as an USB host, but the CH376 can be configured as a device as well; so just for fun I wrote [software to use a Rookie Drive as a device](https://github.com/Konamiman/NestorDevice).

Although it's an amateur product, Rookie Drive is not open source hardware; but it's not rocket science either: it's just a CH376 chip mapped to a couple of Z80 ports, and anyone with MSX hardware design knowledge can create a clone... which is exactly what [the MSX-USB project](https://github.com/S0urceror/MSX-USB) does; this one, yes, it's open source hardware.

So I've linked the MSX-USB project in the PID description file, but I prefer to keep the name "Rookie Drive" since it's the original project and is more well-known in the MSX community.

Video showing a MSX computer using a Rookie Drive in device mode to act as an USB keyboard: https://twitter.com/konamiman/status/1412516715318087681