### PR TITLE
Remove owner name from title identifiers as documentation suggests

### DIFF
--- a/1209/B0B0/index.md
+++ b/1209/B0B0/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Monero Bootloader
+title: Bootloader
 owner: Monero
 license: CERN
 site: https://getmonero.org/

--- a/1209/C0DA/index.md
+++ b/1209/C0DA/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Monero Firmware
+title: Firmware
 owner: Monero
 license: CERN
 site: https://getmonero.org/

--- a/1209/D00D/index.md
+++ b/1209/D00D/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Monero Developer
+title: Developer
 owner: Monero
 license: CERN
 site: https://getmonero.org/


### PR DESCRIPTION
According to documentation:

> Titles will be prefixed with the name of your organisation, so don’t include that in the title.
>
...so let's correct this problem in B0B0, C0DA, and D00D. Thanks.