### PR TITLE
Add earth.li org and Desk Viking PID (0xDE5C)

### DIFF
--- a/1209/DE5C/index.md
+++ b/1209/DE5C/index.md
@@ -6,3 +6,4 @@ site: https://github.com/u1f35c/desk-viking
 source: https://github.com/u1f35c/desk-viking
 ---
 An STM32 based debug device which is inspired by the Dangerous Prototypes Bus Pirate.
+

--- a/1209/DE5C/index.md
+++ b/1209/DE5C/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+owner: earth.li
+license: GPLv3
+site: https://github.com/u1f35c/desk-viking
+source: https://github.com/u1f35c/desk-viking
+---
+An STM32 based debug device which is inspired by the Dangerous Prototypes Bus Pirate.

--- a/org/earth.li/index.md
+++ b/org/earth.li/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: earth.li
+site: https://www.earth.li/
+---
+A collection of random geeks.


### PR DESCRIPTION
This is a project to enable use of STM32F103 debug boards, like the Maple Mini, as an enhanced clone of the Dangerous Prototypes Bus Pirate.