### PR TITLE
Add Oak Dev Tech PixelWing 0x4DF0

### DIFF
--- a/1209/4DF0/index.md
+++ b/1209/4DF0/index.md
@@ -4,5 +4,5 @@ title: PixelWing ESP32-S2
 owner: OakDevelopmentTechnologies
 license: MIT
 site: https://github.com/skerr92/odt-dev-boards/tree/master/boards/PixelWing-ESP32
-source: https://github.com/skerr92/circuitpython/tree/add-ODT-PixelWing-esp/ports/esp32s2/boards/odt-pixelwing-esp32-s2
+source: https://github.com/skerr92/circuitpython/tree/add-ODT-PixelWing-esp/ports/esp32s2/boards/odt_pixelwing_esp32_s2
 ---

--- a/1209/4DF0/index.md
+++ b/1209/4DF0/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: PixelWing ESP32-S2
+owner: OakDevelopmentTechnologies
+license: MIT
+site: https://github.com/skerr92/odt-dev-boards/tree/master/boards/PixelWing-ESP32
+source: https://github.com/skerr92/circuitpython/tree/add-ODT-PixelWing-esp/ports/esp32s2/boards/odt-pixelwing-esp32-s2
+---


### PR DESCRIPTION
This is to add a PID for the ODT PixelWing ESP32-S2 board for CircuitPython Support.