### PR TITLE
Adding new Org [MetalBoards] and Pid [8191]

### DIFF
--- a/1209/8191/index.md
+++ b/1209/8191/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Insane MacroPad
+owner: MetalBoards
+license: MIT
+site: https://MetalBoards.tech/
+source: https://github.com/MetalBoards/InsaneMacroPad
+---
+The Insane MacroPad is a 16 Key Macro Pad with Dual Encoders powered by an Arduino Pro Micro

--- a/org/MetalBoards/index.md
+++ b/org/MetalBoards/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Metal Boards
+site: https://MetalBoards.tech/
+---
+Team making Small Distribution Keyboard & Macropad Projects


### PR DESCRIPTION
### Description

MetalBoards is creating a new 4 x 4 Macro KeyPad which is called InsaneMacroPad. 

The desired PID is 1209/8191

owner: MetalBoards
license: MIT
site: https://github.com/MetalBoards/InsaneMacroPad/README.md
source: https://github.com/MetalBoards/InsaneMacroPad