### PR TITLE
PID Request for Sensor Watch

### DIFF
--- a/1209/2150/index.md
+++ b/1209/2150/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Sensor Watch UF2 Bootloader
+owner: oddlyspecific
+license: CC-BY-SA 4.0 (hardware), MIT (firmware)
+site: https://github.com/joeycastillo/Sensor-Watch
+source: https://github.com/joeycastillo/uf2-samdx1
+---
+This PID identifies the Sensor Watch when in bootloader mode. When the Sensor Watch is running as a normal USB device, it uses [PID 2151](https://pid.codes/1209/2151/).

--- a/1209/2151/index.md
+++ b/1209/2151/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: Sensor Watch
 owner: oddlyspecific
 license: CC-BY-SA 4.0 (hardware), MIT (firmware)
-site: https://github.com/joeycastillo/Sensor-Watch
-source: https://github.com/joeycastillo/uf2-samdx1
+site: https://www.sensorwatch.net/
+source: https://github.com/joeycastillo/Sensor-Watch
 ---
 The Sensor Watch is a board replacement for the classic Casio F-91W wristwatch. It is powered by a Microchip SAM L22 microcontroller with built-in segment LCD controller. You can write your own programs for the watch using the provided watch library, program the watch over USB using the built-in [UF2 bootloader](https://pid.codes/1209/2150/), and then install the board in your existing watch case to run your own software on your wrist.

--- a/1209/2151/index.md
+++ b/1209/2151/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Sensor Watch
+owner: oddlyspecific
+license: CC-BY-SA 4.0 (hardware), MIT (firmware)
+site: https://github.com/joeycastillo/Sensor-Watch
+source: https://github.com/joeycastillo/uf2-samdx1
+---
+The Sensor Watch is a board replacement for the classic Casio F-91W wristwatch. It is powered by a Microchip SAM L22 microcontroller with built-in segment LCD controller. You can write your own programs for the watch using the provided watch library, program the watch over USB using the built-in [UF2 bootloader](https://pid.codes/1209/2150/), and then install the board in your existing watch case to run your own software on your wrist.

--- a/org/oddlyspecific/index.md
+++ b/org/oddlyspecific/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Oddly Specific Objects
+site: https://www.oddlyspecific.org
+---
+Oddly Specific Objects aims to create comprehensible open source designs that democratize the knowledge required to create useful gadgets.


### PR DESCRIPTION
The Sensor Watch is an open hardware board swap for the Casio F-91W wristwatch. This PR requests two PIDs: one for the device, and another for the device when running in UF2 bootloader mode.