### PR TITLE
PID requests for 4key & 6key keyboards (0x3305, 0x3306)

### DIFF
--- a/1209/3304/index.md
+++ b/1209/3304/index.md
@@ -1,11 +1,11 @@
 ---
 layout: pid
-title: 3-Key-Ecosystem 2key2
+title: 2key-keyboards
 owner: 3-Key-Ecosystem
 license: Apache 2.0
 site: https://github.com/softplus/3keyecosystem
-source: https://github.com/softplus/3keyecosystem/tree/main/2key2
+source: https://github.com/softplus/3keyecosystem/tree/main/2key
 ---
 
-This is a 2x1 switch USB macro-keyboard running on QMK.
-It has 2-LED RGB backlighting, and uses a modular base-board.
+This is for my 2x1 switch USB macro-keyboards running on QMK.
+It's used by both 2key1 (single LED per key) and 2key2 (RGB WS2812B LED per key), and uses a modular base-board.

--- a/1209/3305/index.md
+++ b/1209/3305/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: 4key-keyboards
+owner: 3-Key-Ecosystem
+license: Apache 2.0
+site: https://github.com/softplus/3keyecosystem
+source: https://github.com/softplus/3keyecosystem/tree/main/4key
+---
+
+This is for my 2x2 switch USB macro-keyboards running on QMK.
+It's used by both 4key1 (single LED per key) and 4key2 (RGB WS2812B LED per key), and uses a modular base-board.

--- a/1209/3306/index.md
+++ b/1209/3306/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: 6key-keyboards
+owner: 3-Key-Ecosystem
+license: Apache 2.0
+site: https://github.com/softplus/3keyecosystem
+source: https://github.com/softplus/3keyecosystem/tree/main/6key
+---
+
+This is for my 2x2 switch USB macro-keyboards running on QMK.
+It's used by both kai6 (single LED per key) and 6key2 (RGB WS2812B LED per key), and uses a modular base-board.


### PR DESCRIPTION
I've made 2 more keyboards that I'd like to have separate PIDs for. The keyboards run QMK, and I have links to all relevant files that should be needed to produce them (schematics, EasyEDA JSON exports, BOM files). They're all under Apache 2.0 license. 

I also refactored the documentation on my side for the "2key" keyboards, which are under PID 0x3304, so I've updated the link here too. 