### PR TITLE
Request PID: 5AF1 for ButterStick DFU Bootloader

### DIFF
--- a/1209/5AF1/index.md
+++ b/1209/5AF1/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: ButterStick DFU Bootloader
+owner: GoodStuffDepartment
+license: CERN OHL v1.2, BSD-2-Clause
+site: https://github.com/butterstick-fpga
+source: https://github.com/butterstick-fpga/butterstick-hardware
+---
+ButterStick is a compact ECP5 FPGA development board with DDR3L, High-speed USB,Gigabit ethernet, and SYZYGY interfaces


### PR DESCRIPTION
ButterStick is an OSHW ECP5 based FPGA development board. 
Hardware files (KiCad Src, Gerbers, Schematics) here: https://github.com/butterstick-fpga/butterstick-hardware

I'm using a soft-cpu, LiteX, Vexriscv, LUNA and TinyUSB to create a USB DFU bootloader. 
Source code here: https://github.com/butterstick-fpga/butterstick-bootloader
