### PR TITLE
Request PID 557D for SSTuino II

### DIFF
--- a/1209/557D/index.md
+++ b/1209/557D/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: SSTuino II
+owner: FourierIndustries
+license: CC-BY-SA
+site: https://github.com/FourierIndustries-LLP/SSTuino-II
+source: https://github.com/FourierIndustries-LLP/SSTuino-II
+---

--- a/org/FourierIndustries/index.md
+++ b/org/FourierIndustries/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: FourierIndustries
+site: http://sstuino.fourier.industries/
+---
+FourierIndustries LLP is a Singapore-based electronics design firm for microcontroller and IoT applications.


### PR DESCRIPTION
Hi, I am requesting PID 0x557D for the SSTuino II, an educational and industrial microcontroller board which uses a USB serial interface with a custom controller to achieve both USB-UART and AVR UPDI programming functionalities.

Link to repo: https://github.com/FourierIndustries-LLP/SSTuino-II

This product is licensed under CC-BY-SA 4.0.

Thank you!