### PR TITLE
adding ODT Cast-Away RP2040 PID: 4DF2

### DIFF
--- a/1209/4DF2/index.md
+++ b/1209/4DF2/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Cast-Away RP2040
+owner: OakDevelopmentTechnologies
+license: MIT
+site: https://github.com/skerr92/odt-dev-boards/tree/master/boards/Cast-Away-RP2040
+source: https://github.com/skerr92/circuitpython/tree/add-odt-castaway2040/ports/raspberrypi/boards/odt_cast_away_rp2040
+---


### PR DESCRIPTION
adding cast-away rp2040 with PID 4DF2 for CircuitPython Support