### PR TITLE
Assign PID DE1A to Delta Pico calculator

### DIFF
--- a/1209/DE1A/index.md
+++ b/1209/DE1A/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Delta Pico
+owner: AaronChristiansen
+license: MIT
+site: https://github.com/AaronC81/delta-pico
+source: https://github.com/AaronC81/delta-pico
+---
+The Delta Pico is a powerful scientific calculator built around the Raspberry Pi Pico, with a 2.8" 240x320 colour display.

--- a/org/AaronChristiansen/index.md
+++ b/org/AaronChristiansen/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Aaron Christiansen
+site: https://aaronc.cc/
+---
+Programmer and electronics hobbyist


### PR DESCRIPTION
I'm requesting a PID for my Delta Pico scientific calculator, as it's now able to mount itself as a mass storage device.

This is my first PID, so I've also created an org for myself.

Thanks!