### PR TITLE
Request 1209/ACEB for OpenLightingProject's rp2040-dongle

### DIFF
--- a/1209/ACEB/index.md
+++ b/1209/ACEB/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: rp2040-dongle
+owner: openlightingproject
+license: GPL
+site: https://github.com/OpenLightingProject/rp2040-dongle
+source: https://github.com/OpenLightingProject/rp2040-dongle
+---
+
+An open source [DMX512](https://en.wikipedia.org/wiki/DMX512) transmitter, 
+based on 
+[RaspberryPi's Pico board](https://www.raspberrypi.org/documentation/pico/getting-started/).
+Up to 16 universes can be transmitted, DMX input is in development.


### PR DESCRIPTION
Hi, this PR requests 1209/ACEB for a new piece of hardware developed in the OpenLightingProject organization.

The hardware uses/embeds a RP2040-Pico board by RaspberryPi. The firmware source is quite mature and in the main branch.

The hardware (schematics and PCB layout) is free & open as well, of course. It's not yet merged to the main branch but is available here (KiCad source files): https://github.com/OpenLightingProject/rp2040-dongle/tree/hardware/hardware. Renderings (PDFs) are automatically generated using GitHub actions: https://github.com/OpenLightingProject/rp2040-dongle/suites/4741501920/artifacts/130997826