### PR TITLE
PID Request: 2730 for RubyLink

### DIFF
--- a/1209/2730/index.md
+++ b/1209/2730/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: RubyLink
+owner: Misaka0x2730
+license: CERN-OHL-P
+site: https://github.com/Misaka0x2730/RubyLink
+source: https://github.com/Misaka0x2730/RubyLink
+---
+Open source USB/Ethernet ARM debugger with 2 target interfaces

--- a/org/Misaka0x2730/index.md
+++ b/org/Misaka0x2730/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Misaka0x2730
+site: https://github.com/Misaka0x2730
+---
+Embedded engineer and open hardware enthusiast.


### PR DESCRIPTION
Hello!
I'm requesting PID 0x2730 for the RubyLink, USB/Ethernet ARM debugger with 2 target interfaces (one is isolated) based on RP2040.
The firmware is under development, but the firmware is based on [BlackMagic Probe firmware](https://github.com/blacksphere/blackmagic/)

Link to hardware: https://github.com/Misaka0x2730/RubyLink

This hardware is licensed under CERN-OHL-P.

Thank you!

