### PR TITLE
Add OpenAudioGear ADATface, secondary USB interface - 0xADA2

### DIFF
--- a/1209/ADA2/index.md
+++ b/1209/ADA2/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: ADATface - ADAT USB2 high speed audio interface
+owner: OpenAudioGear
+license: CERN-OHL-W-2.0
+site: https://github.com/hansfbaier/adat-usb2-audio-interface 
+source: https://github.com/hansfbaier/adat-usb2-audio-interface 
+---
+An Open Source USB2 high speed <-> ADAT Lightpipe audio interface
+I need another ID for the second USB interface on the soundcard.
+Operating systems choke if both interfaces with different layouts
+enumerate with the same ID.


### PR DESCRIPTION
Hi, 
I would need another ID for the secondary USB interface of the soundcard
which enumerates differently than the primary interface.
Operating systems seem to behave strangely when a different
soundcard enumerates with the same ID,
especially when both are plugged in at the same host.
