### PR TITLE
PID Request: TinyGo — A Go Compiler for Small Places

### DIFF
--- a/1209/9090/index.md
+++ b/1209/9090/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: USB
+owner: TinyGo
+license: MIT
+site: https://www.tinygo.org/
+source: https://github.com/tinygo-org/tinygo/
+---

--- a/org/TinyGo/index.md
+++ b/org/TinyGo/index.md
@@ -1,0 +1,16 @@
+---
+layout: org
+title: TinyGo 
+site: http://www.tinygo.org/
+---
+TinyGo brings the Go programming language to embedded systems and to the modern
+web by creating a new compiler based on LLVM.
+
+You can compile and run TinyGo programs on over 60 different microcontroller 
+boards such as the BBC micro:bit and the Arduino Uno.
+
+TinyGo can also produce WebAssembly (WASM) code which is very compact in size.
+You can compile programs for web browsers, as well as for server and edge 
+computing environments that support the WebAssembly System Interface (WASI)
+family of interfaces.
+


### PR DESCRIPTION
Requesting a unique PID for TinyGo-supported devices, which often already have a VID/PID specific to the vendor's officially supported firmware. Since TinyGo completely replaces this firmware and has developed its own independent USB software stack, it would be best to not reuse the original vendor's well-earned VID/PID, and instead we use our own separate PID with ties to the open source community.