### PR TITLE
PID  Request: DA7A for nanoBoot (AVR HID Bootloader)

### DIFF
--- a/1209/DA7A/index.md
+++ b/1209/DA7A/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: nanoBoot
+owner: rot
+license: MIT
+site: https://github.com/volium/nanoBoot
+source: https://github.com/volium/nanoBoot
+---
+nanoBoot is a USB HID bootloader that fits in the smallest available boot size on the ATMegaXXu4 devices, 256 words or 512 bytes.

--- a/org/rot/index.md
+++ b/org/rot/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Rodrigo Torres
+site: http://volium.github.io
+---
+Designer and developer of open source/open hardware devices.


### PR DESCRIPTION
Hello!

I'm requesting PID 0xDA7A for the Open Source project [nanoBoot](https://github.com/volium/nanoBoot), a USB/HID Bootloader for ATmegaXXU4 family of devices.

The code is well documented and flexible enough to enough to accommodate HW variations, so it is not tight to a specific board; only the MCU itself needs to be supported.

The code is released under the MIT license.

Thank you!