### PR TITLE
Movuino OpenHealthBand

### DIFF
--- a/1209/7402/index.md
+++ b/1209/7402/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: OpenHealthBand
+owner: Movuino
+license: MIT
+site: https://movuino.github.io/OpenHealthBandFirmware/
+source: https://github.com/movuino/OpenHealthBandFirmware
+---
+Open Health Band is a low-tech open-source wearable featuring sensors such as accelerometer, gyroscope and magnetometer, aswell as heart rate monitoring.
+Schematics can be found at [https://github.com/movuino/OpenHealthBand](https://github.com/movuino/OpenHealthBand)

--- a/org/Movuino/index.md
+++ b/org/Movuino/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Movuino
+site: http://movuino.com
+---
+Movuino is an open-source development platform dedicated to motion and gestures. Basically it’s an electronic board embedding sensors, microcontroller and wireless communication component. This platform gives to citizens, whether they are scientists, engineers, designers, artists… the potential to prototype meaningful ideas involving motion sensing in many fields of application: health, education, sport… and this in many contexts: research, industry, art…


### PR DESCRIPTION
Requesting PID 7402 for Movuino OpenHealthBand, a low-tech open-source wearable for education and health.
- Hardware can be found at [https://github.com/movuino/OpenHealthBand](https://github.com/movuino/OpenHealthBandl)
- Software can be found at [https://github.com/movuino/OpenHealthBandFirmware](https://github.com/movuino/OpenHealthBandFirmware)

The PID is needed to create our own bootloader, sources can be found [here](https://github.com/movuino/movuino-board-index/tree/development/bootloaders)