### PR TITLE
Request for a PID for PewPew LCD device.

### DIFF
--- a/1209/D1B5/index.md
+++ b/1209/D1B5/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: PewPew LCD
+owner: PewPew
+license: CC BY-SA 4.0
+site: https://pewpew.rtfd.io
+source: https://github.com/pypewpew/pewpew-lcd
+---

--- a/org/PewPew/index.md
+++ b/org/PewPew/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: PewPew
+site: https://pewpew.rtfd.io
+---
+An open source project creating cheap and easy to use Python handhelds for use
+in programming workshops, along with content for those workshops, and any other supporting materials.


### PR DESCRIPTION
PewPew is a family of handheld devices running CircuitPython designed
for use in programming workshops. PewPew LCD is a new device in this
family, using a monochrome LCD display.

The VID/PID is required to be able to merge the board definition for
this device into the CircuitPython repository. The pull request for
that is at https://github.com/adafruit/circuitpython/pull/6331