### PR TITLE
Request PID 1209:7672 for VR61 - Swappable Microcontroller Custom Keyboard

### DIFF
--- a/1209/7672/index.md
+++ b/1209/7672/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: VR61 Keyboard
+owner: Tecsmith
+license: MIT
+site: https://tecsmith.com.au
+source: https://github.com/Tecsmith/vr61-keyboard-pcb
+---

--- a/org/Tecsmith/index.md
+++ b/org/Tecsmith/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Tecsmith
+site: https://tecsmith.com.au
+---
+Tecsmith is an open source contributor.


### PR DESCRIPTION
The VR61 is a 60%, 61-key "pok3r" style mechanical keyboard PCB that is a drop in fit (or replace) for the ample GH60 cases in the market, or a drop in hotswap replacement for the AP2 keyboard.  What makes this PCB unique is that it features the SparkFun's MicroMod processor M.2 module connector, meaning you have a choice of MCU to use.

The HW: https://github.com/Tecsmith/vr61-keyboard-pcb
The SW: https://github.com/Tecsmith/vr61-keyboard-qmk
