### PR TITLE
Create PID C680 for picoframe

### DIFF
--- a/1209/C680/index.md
+++ b/1209/C680/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: picoframeST
+owner: dedChar
+license: MIT
+site: http://picofra.me/
+source: https://gitlab.com/dedChar/picoframeST
+---

--- a/org/dedChar/index.md
+++ b/org/dedChar/index.md
@@ -3,3 +3,4 @@ layout: org
 title: dedChar
 ---
 Someone who likes (embedded) software development.
+

--- a/org/dedChar/index.md
+++ b/org/dedChar/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: dedChar
+---
+Someone who likes (embedded) software development.


### PR DESCRIPTION
Requesting PID 0xC680 for a digital picture frame that uses USB to configure and upload images to the device.