### PR TITLE
Request PIDs 1209:9101 and 1209:9102 for Sim Racing Shields

### DIFF
--- a/1209/9101/index.md
+++ b/1209/9101/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Sim Racing Shifter
+owner: dmadison
+license: GPLv3
+site: https://github.com/dmadison/Sim-Racing-Shields
+source: https://github.com/dmadison/Sim-Racing-Shields
+---

--- a/1209/9102/index.md
+++ b/1209/9102/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Sim Racing Pedals
+owner: dmadison
+license: GPLv3
+site: https://github.com/dmadison/Sim-Racing-Shields
+source: https://github.com/dmadison/Sim-Racing-Shields
+---

--- a/org/dmadison/index.md
+++ b/org/dmadison/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Dave Madison
+site: http://www.github.com/dmadison
+---
+Creator of open source USB projects.


### PR DESCRIPTION
These two devices work as standalone USB adapters for the Logitech gear shifter and pedal peripherals.

Hardware: https://github.com/dmadison/Sim-Racing-Shields
Software: https://github.com/dmadison/Sim-Racing-Arduino

Compiled firmware will be included in the hardware repository after this PR is approved. Thank you!