### PR TITLE
Ghoul keyboard PID reservation.

### DIFF
--- a/1209/4920/index.md
+++ b/1209/4920/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Ghoul Mechanical Keyboard
+owner: tzarc
+license: GPLv3
+site: https://github.com/tzarc/ghoul
+source: https://github.com/tzarc/ghoul
+---
+The Ghoul is a 40-key mechanical keyboard -- dual 4x5 with an RGB OLED and encoder. It also sports a MicroMod connector for hot-swap of MCU!


### PR DESCRIPTION
Requesting the allocation of 1209:4920 for the [Ghoul mechanical keyboard](https://github.com/tzarc/ghoul).

The link above points at the hardware design files.
The software sources can be found [here](https://github.com/tzarc/qmk_build/tree/master/keyboards/tzarc-ghoul) under GPLv3. Will PR to [QMK](https://github.com/qmk/qmk_firmware) once PID is granted.