### PR TITLE
request PID for Pragmatic Keyboard

### DIFF
--- a/1209/A805/index.md
+++ b/1209/A805/index.md
@@ -1,9 +1,8 @@
 ---
 layout: pid
 title: Pragmatic Keyboard 務實鍵盤
-owner: James Sa
+owner: Pragmatic
 license: MIT
 site: https://github.com/jamessa/Pragmatic
 source: https://github.com/jamessa/Pragmatic
 ---
-

--- a/1209/A805/index.md
+++ b/1209/A805/index.md
@@ -6,3 +6,4 @@ license: MIT
 site: https://github.com/jamessa/Pragmatic
 source: https://github.com/jamessa/Pragmatic
 ---
+

--- a/1209/A805/index.md
+++ b/1209/A805/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Pragmatic Keyboard 務實鍵盤
+owner: James Sa
+license: MIT
+site: https://github.com/jamessa/Pragmatic
+source: https://github.com/jamessa/Pragmatic
+---

--- a/org/Pragmatic/index.md
+++ b/org/Pragmatic/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Pragmatic Keyboard 務實鍵盤
+site: https://github.com/jamessa/Pragmatic
+source: https://github.com/jamessa/Pragmatic
+---


### PR DESCRIPTION
Hi, thank you for maintaining the pid code. I'd like to register a PID for my open source keyboard. It's got around 100 users already, so I think it's time to make it more friendly for future users. Thanks for your precious time.

Hardware https://github.com/jamessa/Pragmatic with MIT license.
Firmware https://github.com/jamessa/vial-qmk/tree/jsa/keyboards/jsa will submit to QMK once PID is approved.
