### PR TITLE
Updates for bshockley boards.

### DIFF
--- a/1209/2017/index.md
+++ b/1209/2017/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: Mini SAM M4
 owner: bshockley
 license: MIT
-site: https://www.minisam.cc
+site: https://www.minifigboards.com
 source: https://github.com/bwshockley/Mini-SAM
 ---
-[Benjamin Shockley Github - Mini SAM](https://github.com/bwshockley/Mini-SAM) is a minifigure shaped development board.  License files located on the Github repository.
+Mini SAM M4 is a minifigure shaped development board.  License files located on the Github repository.

--- a/1209/7102/index.md
+++ b/1209/7102/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: Mini SAM M0
 owner: bshockley
 license: MIT
-site: https://www.minisam.cc
+site: https://www.minifigboards.com
 source: https://github.com/bwshockley/Mini-SAM
 ---
-[Benjamin Shockley Github - Mini SAM M0](https://github.com/bwshockley/Mini-SAM) is a minifigure shaped development board.  License files located on the Github repository.
+Mini SAM M0 is a minifigure shaped development board.  License files located on the Github repository.

--- a/1209/7103/index.md
+++ b/1209/7103/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Fig Pi
+owner: bshockley
+license: MIT
+site: https://www.minifigboards.com
+source: https://github.com/bwshockley/FigPi
+---
+Fig Pi is a minifigure shaped development board.  License files located on the Github repository.

--- a/org/bshockley/index.md
+++ b/org/bshockley/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
 title: Benjamin Shockley
-site: https://github.com/bwshockley/Mini-SAM
+site: https://github.com/bwshockley
 ---
-I am an aerospace engineer who dabbles in small circuit design for fun.  I create circuits that I find fun and interesting and share them with others who might enjoy then as well.  I can be found on Twitter @bwshockley, and additional details for projects that utilize pid.codes can be found at https://www.minisam.cc.
+I am an aerospace engineer who dabbles in small circuit design for fun.  I create circuits that I find fun and interesting and share them with others who might enjoy then as well.  I can be found on Twitter @bwshockley, and additional details for projects that utilize pid.codes can be found at https://www.minifigboards.com.


### PR DESCRIPTION
Updated the org information to reflect the latest website.  Updated the existing board ids; 2017 and 7102.  Added a new board for 7103 for Fig Pi - a RP2040 based dev board.