### PR TITLE
Add HydraBus org and HydraUSB3 & HydraUSB3 bootloader PIDs

### DIFF
--- a/1209/B569/index.md
+++ b/1209/B569/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: HydraUSB3 bootloader
+owner: HydraBus
+license: Apache-2.0 license
+site: https://github.com/hydrausb3/hydrausb3_fw
+source: https://github.com/hydrausb3/hydrausb3_fw
+---
+HydraUSB3 dev kit for WCH CH569W MCU series RISC-V MCU 32-Bit Embedded Evaluation Board
+See https://hydrabus.com/hydrausb3-v1-0-specifications

--- a/1209/B569/index.md
+++ b/1209/B569/index.md
@@ -6,5 +6,5 @@ license: Apache-2.0 license
 site: https://github.com/hydrausb3/hydrausb3_fw
 source: https://github.com/hydrausb3/hydrausb3_fw
 ---
-HydraUSB3 dev kit for WCH CH569W MCU series RISC-V MCU 32-Bit Embedded Evaluation Board
+HydraUSB3 bootloader PID for HydraUSB3 dev kit for WCH CH569W MCU series RISC-V MCU 32-Bit Embedded Evaluation Board
 See https://hydrabus.com/hydrausb3-v1-0-specifications

--- a/1209/C569/index.md
+++ b/1209/C569/index.md
@@ -6,5 +6,5 @@ license: Apache-2.0 license
 site: https://github.com/hydrausb3/hydrausb3_fw
 source: https://github.com/hydrausb3/hydrausb3_fw
 ---
-HydraUSB3 dev kit for WCH CH569W MCU series RISC-V MCU 32-Bit Embedded Evaluation Board
+HydraUSB3 main firmware PID for HydraUSB3 dev kit for WCH CH569W MCU series RISC-V MCU 32-Bit Embedded Evaluation Board
 See https://hydrabus.com/hydrausb3-v1-0-specifications

--- a/1209/C569/index.md
+++ b/1209/C569/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: HydraUSB3
+owner: HydraBus
+license: Apache-2.0 license
+site: https://github.com/hydrausb3/hydrausb3_fw
+source: https://github.com/hydrausb3/hydrausb3_fw
+---
+HydraUSB3 dev kit for WCH CH569W MCU series RISC-V MCU 32-Bit Embedded Evaluation Board
+See https://hydrabus.com/hydrausb3-v1-0-specifications

--- a/org/HydraBus/index.md
+++ b/org/HydraBus/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: HydraBus
+site: https://hydrabus.com
+---
+Open source multi-tool hardware


### PR DESCRIPTION
Requesting the allocation of 1209:B569 (HydraUSB3 bootloader)
Requesting the allocation of 1209:C569 (HydraUSB3)

HydraUSB3 Open Source firmware & lib [Apache License 2.0](https://github.com/hydrausb3/hydrausb3_fw/blob/main/LICENSE)
https://github.com/hydrausb3/hydrausb3_fw