### PR TITLE
Adds new board Challenger RP2040 SubGHz to the list.

### DIFF
--- a/1209/7382/index.md
+++ b/1209/7382/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Challenger RP2040 SUBGHz - CDC Serial port
+owner: iLabs
+license: CERN Open Hardware Licence v1.2
+site: https://ilabs.se/challenger-rp2040-subghz-rfm69hcw-datasheet
+source: https://github.com/PontusO/circuitpython
+---
+The Challenger RP2040 SubGHz board is an Arduino and Circuitpython compatible Adafruit Feather format micro controller board with an integrated SubGHz radio module

--- a/1209/7382/index.md
+++ b/1209/7382/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: Challenger RP2040 SUBGHz - CDC Serial port
 owner: iLabs
 license: CERN Open Hardware Licence v1.2
-site: https://ilabs.se/challenger-rp2040-subghz-rfm69hcw-datasheet
-source: https://github.com/PontusO/circuitpython
+site: https://ilabs.se/product/challenger-rp2040-subghz-868mhz
+source: https://github.com/PontusO/circuitpython,https://github.com/PontusO/arduino-pico
 ---
-The Challenger RP2040 SubGHz board is an Arduino and Circuitpython compatible Adafruit Feather format micro controller board with an integrated SubGHz radio module
+The Challenger RP2040 SubGHz board is an Arduino and Circuitpython compatible Adafruit Feather format micro controller board with an integrated SubGHz radio module.


### PR DESCRIPTION
As the title suggests this is a request to get a PID for our new board Challenger RP2040 SubGHz. This board is supported both by the arduino-pico framework as well as circuitpython.