### PR TITLE
Add pid for 42. Keebs Frood (mainly for CircuitPython)

### DIFF
--- a/1209/4203/index.md
+++ b/1209/4203/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Frood
+owner: 42.Keebs
+license: GPL-3.0
+site: http://42keebs.eu/
+source: http://github.com/piit79/Frood
+---


### PR DESCRIPTION
Another project in need of a PID :) The Frood is a Pro Micro replacement based on RP2040 with a standard pinout compatible with the SparkFun Pro Micro RP2040. Thanks!