### PR TITLE
add PassPico PID

### DIFF
--- a/1209/E128/index.md
+++ b/1209/E128/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: PassPico
+owner: brxken128
+license: BSD 2-Clause
+site: https://github.com/brxken128/passpico
+source: https://github.com/brxken128/passpico
+---

--- a/org/brxken128/index.md
+++ b/org/brxken128/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: brxken128
+site: https://github.com/brxken128/
+---
+a rust OSS developer


### PR DESCRIPTION
This adds `0xE128` for the [PassPico](https://github.com/brxken128/passpico) and the `brxken128` org.