### PR TITLE
Requesting PID for MultiBus Bridge

### DIFF
--- a/1209/2007/index.md
+++ b/1209/2007/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: MultiBus Bridge
+owner: MultiBus
+license: BSD-2-Clause
+site: https://github.com/mringwal/multibus
+source: https://github.com/mringwal/multibus/tree/main/firmware/pico
+---
+
+MultiBus project aims to use common embedded interface such as 
+GPIO, I2C, I2S, SPIO, SPIO, .. from a regular host system via
+common development kits like Raspberry Pi Pico or ESP32.

--- a/org/MultiBus/index.md
+++ b/org/MultiBus/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: MultiBus
+site: https://github.com/mringwal/multibus
+---
+
+MultiBus project aims to use common embedded interface such as 
+GPIO, I2C, I2S, SPIO, SPIO, .. from a regular host system via
+common development kits like Raspberry Pi Pico or ESP32.


### PR DESCRIPTION
https://github.com/mringwal/multibus

MultiBus project aims to use common embedded interface such as 
GPIO, I2C, I2S, SPIO, SPIO, .. from a regular host system via
common development kits like Raspberry Pi Pico or ESP32.

First device with USB would be Raspberry Pi Pico.

Thanks!