### PR TITLE
Add Oxide Keyboard org

### DIFF
--- a/1209/6F78/index.md
+++ b/1209/6F78/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: oxikey HID
+owner: OxideKeyboard
+license: MIT
+site: http://www.oxidekeyboard.com
+source: https://github.com/n8tlarsen/oxikey
+---

--- a/1209/6F78/index.md
+++ b/1209/6F78/index.md
@@ -6,3 +6,4 @@ license: MIT
 site: http://www.oxidekeyboard.com
 source: https://github.com/n8tlarsen/oxikey
 ---
+

--- a/1209/6F79/index.md
+++ b/1209/6F79/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: oxikey MSC
+owner: OxideKeyboard
+license: MIT
+site: http://www.oxidekeyboard.com
+source: https://github.com/n8tlarsen/oxikey
+---

--- a/org/OxideKeyboard/index.md
+++ b/org/OxideKeyboard/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Oxide Keyboard
+site: http://www.oxidekeyboard.com
+---
+Creator of the oxikey keyboard firmware library for developers written in Rust.


### PR DESCRIPTION
The oxikey firmware will use two endpoints, one for HID and one for mass storage to update firmware.