### PR TITLE
Add JackMacWindows organization + assign 1209/CD07 to "PSG MIDI Device"

### DIFF
--- a/1209/CD07/index.md
+++ b/1209/CD07/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: PSG MIDI Device
+owner: JackMacWindows
+license: GPLv2
+site: https://mcjack123.github.io/PSG/
+source: https://github.com/MCJack123/PSG/
+---
+Programmable 16-channel synthesizer board with a MIDI interface.

--- a/org/JackMacWindows/index.md
+++ b/org/JackMacWindows/index.md
@@ -4,3 +4,4 @@ title: JackMacWindows
 site: https://mcjack123.github.io/
 ---
 I'm JackMacWindows, and I'm a hobbyist developer/hacker, mainly known for the [CraftOS-PC](https://www.craftos-pc.cc) fantasy terminal and other projects in the ComputerCraft community, but I also like to make hardware using the Raspberry Pi Pico and other microcontrollers.
+

--- a/org/JackMacWindows/index.md
+++ b/org/JackMacWindows/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: JackMacWindows
+site: https://mcjack123.github.io/
+---
+I'm JackMacWindows, and I'm a hobbyist developer/hacker, mainly known for the [CraftOS-PC](https://www.craftos-pc.cc) fantasy terminal and other projects in the ComputerCraft community, but I also like to make hardware using the Raspberry Pi Pico and other microcontrollers.


### PR DESCRIPTION
I am requesting an assignment of USB PID `CD07` for my PSG MIDI Device. This device is a programmable synthesizer/sound generator using a Raspberry Pi Pico as a USB host, which communicates over USB MIDI protocol.

The source code is available at [MCJack123/PSG](https://github.com/MCJack123/PSG), which includes sources for the Pico (USB) firmware, PIC microcontroller firmware, board design files, and [a two-part write up](https://mcjack123.github.io/PSG/), licensed under GPLv2.

(Please squash the commits when merging - I did this in the web editor, and I'd appreciate if I don't have to go back to clone & squash them myself ;P)