### PR TITLE
Add Datanoise PicoADK.

### DIFF
--- a/1209/4DAD/index.md
+++ b/1209/4DAD/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: PicoADK
+owner: Datanoise
+license: MIT
+site: https://github.com/DatanoiseTV/PicoADK-Hardware
+source: https://github.com/DatanoiseTV/PicoADK-Firmware-Template
+---

--- a/org/Datanoise/index.md
+++ b/org/Datanoise/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Datanoise
+site: https://datanoise.org
+
+Datanoise is a Berlin-based hardware manufacturer working on open source hardware.


### PR DESCRIPTION
Add Datanoise PicoADK - a Audio Development Kit for building Synthesizers and Music Hardware. Open Firmware.