### PR TITLE
Add CH569 USB3 microcontroller board PID files

### DIFF
--- a/1209/569C/index.md
+++ b/1209/569C/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: USB3 Super Speed microcontroller board
+owner: OpenAudioGear
+license: CERN-OHL-P-2.0
+site: https://github.com/hansfbaier/ch569-usb3-board
+source: https://github.com/hansfbaier/ch569-usb3-board
+---
+An Open Source USB3 Super Speed microcontroller board


### PR DESCRIPTION
I just stress tested and verified the latest board revision. Works!
Ready for PID.
Signed-off-by: Hans Baier <hansfbaier@gmail.com>