### PR TITLE
request PIDs for Riotee board and Riotee probe

### DIFF
--- a/1209/C8A0/index.md
+++ b/1209/C8A0/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Riotee board
+owner: NessieCircuits
+license: CERN-OHL-W-2.0 (hardware), MIT (firmware)
+site: https://github.com/NessieCircuits/Riotee_Board
+source: https://github.com/NessieCircuits/Riotee_ProbeFirmware
+---

--- a/1209/C8A1/index.md
+++ b/1209/C8A1/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Riotee probe
+owner: NessieCircuits
+license: CERN-OHL-W-2.0 (hardware), MIT (firmware)
+site: https://github.com/NessieCircuits/Riotee_ProbeHardware
+source: https://github.com/NessieCircuits/Riotee_ProbeFirmware
+---

--- a/org/NessieCircuits/index.md
+++ b/org/NessieCircuits/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Nessie Circuits
+---
+Nessie Circuits is a small business offering embedded hardware and software solutions to customers from academia and industry.
+
+We are now working on our first product - an open-source battery-free board that runs completely off harvested energy and uses only tiny capacitors as energy storage.


### PR DESCRIPTION
Requesting two PIDs for two of our open-source products. Hardware designs for both products are under Cern OSHW. Both devices use the same MIT-licensed firmware.