### PR TITLE
add DF03 for mi:muz:ch55x

### DIFF
--- a/1209/DF03/index.md
+++ b/1209/DF03/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: mi:muz-ch55x
+owner: TripArts-Music
+license: LGPL2.1
+site: https://www.arduinolibraries.info/libraries/mimuz-ch55x
+source: https://github.com/mimuz/mimuz-ch55x
+---
+An Tiny library of USB MIDI for Deqing Sun's Ch55xduino.
+
+

--- a/1209/DF03/index.md
+++ b/1209/DF03/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: mi:muz-ch55x
+title: mi:muz:ch55x
 owner: TripArts-Music
 license: LGPL2.1
 site: https://www.arduinolibraries.info/libraries/mimuz-ch55x


### PR DESCRIPTION
Hello,

mi:muz-ch55x is a open source USB-MIDI library for ch55xduino with LGPL license.

https://github.com/mimuz/mimuz-ch55x

So, I want to VID/PID. (PID requested: 0xDF03)

I hope so you accept marge my pull request!

Best regards,
Hideyuki Kodama (D.F.Mac. @TripArts Music / mi:muz Project)