### PR TITLE
Add libmcu MADI development board

### DIFF
--- a/1209/E000/index.md
+++ b/1209/E000/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MADI
+owner: libmcu
+license: MIT
+site: https://libmcu.org
+source: https://github.com/libmcu/development-board
+---
+MADI is a development board for platform-independent and vendor-agnostic development.

--- a/1209/E001/index.md
+++ b/1209/E001/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MADI
+owner: libmcu
+license: MIT
+site: https://libmcu.org
+source: https://github.com/libmcu/development-board
+---
+MADI is a development board for platform-independent and vendor-agnostic development.

--- a/org/libmcu/index.md
+++ b/org/libmcu/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: libmcu
+site: https://libmcu.org
+---
+libmcu is an open-source firmware development toolkit.


### PR DESCRIPTION
Two endpoints are used, one for DFU and the other for CDC.

Schematics can be found [here](https://github.com/libmcu/development-board).
Source code can be found [here](https://github.com/libmcu/board-sdk).

Thanks.