### PR TITLE
PID request for teensycore

### DIFF
--- a/1209/F314/index.md
+++ b/1209/F314/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Teensycore
+owner: SharpCoder
+license: MIT
+site: https://github.com/SharpCoder/teensycore
+source: https://github.com/SharpCoder/teensycore
+---
+
+This is a kernel for the Teensy4.0 available to anyone for free with a built-in OTG USB driver.

--- a/org/SharpCoder/index.md
+++ b/org/SharpCoder/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: SharpCoder
+site: https://joshcole.dev/
+---
+
+I am a maker and embedded hobbiest creating kernels, robots, and other exciting devices.


### PR DESCRIPTION
This pull request adds an allocation for the F314 PID 

My project falls within the gray area of your rules, because it is software-only. I've written a kernel from scratch for a well known microcontroller (the Teensy 4.0) and my recent effort includes writing is a functioning USB driver. I am hoping to reserve this PID so I can use it as the default in my kernel and, in turn, for all my hobby projects.

If this is rejected, I would like to update my request to reflect a specific hardware project.

Thank you.