### PR TITLE
Add Deneyap Development Boards

### DIFF
--- a/1209/D000/index.md
+++ b/1209/D000/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Deneyap Kart - CircuitPython
+owner: Turkish Technology Team Foundation
+license: MIT
+site: https://github.com/deneyapkart/
+source: https://github.com/deneyapkart/circuitpython/
+---
+CircuitPython for Deneyap Kart

--- a/1209/D001/index.md
+++ b/1209/D001/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Deneyap Kart G - CircuitPython
+owner: Turkish Technology Team Foundation
+license: MIT
+site: https://github.com/deneyapkart/
+source: https://github.com/deneyapkart/circuitpython/
+---
+CircuitPython for Deneyap Kart G

--- a/1209/D002/index.md
+++ b/1209/D002/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Deneyap Kart 1A - CircuitPython
+owner: Turkish Technology Team Foundation
+license: MIT
+site: https://github.com/deneyapkart/
+source: https://github.com/deneyapkart/circuitpython/
+---
+CircuitPython for Deneyap Kart 1A

--- a/org/DeneyapKart/index.md
+++ b/org/DeneyapKart/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Deneyap Kart
+site: https://deneyapkart.org/
+---
+Open source electronics development boards and modules are initiated by Turkish Technology Team Foundation.


### PR DESCRIPTION
Add Deneyap Development Boards for CircuitPython.

Deneyap Kart (ESP32-WROVER-E-N4R8)
Deneyap Kart 1A (ESP32-WROVER-E-N4R8)
Deneyap Kart G (ESP32-C3FN4)