### PR TITLE
Add 01Space board for Circuitpython

### DIFF
--- a/1209/42B0/index.md
+++ b/1209/42B0/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: RP2040 0.42 LCD
+owner: 01space
+license: MIT
+site: https://github.com/01Space/RP2040-0.42LCD
+source: https://github.com/adafruit/circuitpython
+---
+Raspberry Pi RP2040 development board with a tiny screen.

--- a/org/01space/index.md
+++ b/org/01space/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: 01Space
+site: https://github.com/01Space
+---
+01Space microcontroller board maker.


### PR DESCRIPTION
This is a PID request for running Circuitpython on the 01Space RP2040 0.42 LCD board.
https://github.com/01Space/RP2040-0.42LCD

The board is not open hardware, the maker has no VID and is not requesting a PID from Rapsberry Pi.