### PR TITLE
Add org:bluekeyes and pid:B210

### DIFF
--- a/1209/B210/index.md
+++ b/1209/B210/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Pico 12VRGB HID Controller
+owner: bluekeyes
+license: MIT
+site: https://github.com/bluekeyes/pico-12vrgb-hid-controller
+source: https://github.com/bluekeyes/pico-12vrgb-hid-controller
+---
+
+A HID "Lighting and Illumination"-compatible controller for 12V RGB lighting devices using the Raspberry Pi Pico.

--- a/org/bluekeyes/index.md
+++ b/org/bluekeyes/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: BlueKeyes
+site: http://bluekeyes.com
+---
+Software, hardware, and other projects by Billy Keyes.


### PR DESCRIPTION
I'd like to request PID B210 for my `Pico 12VRGB HID Controller` project:

* Schematics and PCB (KiCAD): https://github.com/bluekeyes/pico-12vrgb-hid-controller/tree/main/hw/pcb
* Firmware: https://github.com/bluekeyes/pico-12vrgb-hid-controller/tree/main/fw
* Host software: https://github.com/bluekeyes/pico-12vrgb-hid-controller/tree/main/cli