### PR TITLE
Request PIDs for Kodachi 6 14 MacroPaws

### DIFF
--- a/1209/6E01/index.md
+++ b/1209/6E01/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: MacroPaw KnGXT
+owner: kodachi614
+license: GPL-3.0-or-later, CERN-OHL-S-2.0
+site: http://github.com/kodachi614/macropaw/
+source: http://github.com/kodachi614/macropaw/
+---
+The MacroPaw KnGXT is a USB HID combining a 14-key hotswappable mechanical
+keyboard (14 keys in a 5x3 grid, with the lower right key being 2U instead of
+1U), two rotary encoders, and a lot of RGB LEBs. It's based on the RP2040 and
+runs customized KMK firmware.

--- a/1209/6E02/index.md
+++ b/1209/6E02/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: MacroPaw KnGYT
+owner: kodachi614
+license: GPL-3.0-or-later, CERN-OHL-S-2.0
+site: http://github.com/kodachi614/macropaw/
+source: http://github.com/kodachi614/macropaw/
+---
+The MacroPaw KnGYT is a USB keyboard with 10 keys in a 5x2 grid and 10 RGB
+LEDs. It's based on the RP2040 and runs customized KMK firmware.

--- a/org/kodachi614/index.md
+++ b/org/kodachi614/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Kodachi 6 14
+site: http://kodachi.com/
+---
+Kodachi 6 14 does open-source hardware and software, notably including the
+MacroPaw and TKPaw RP2040-based keyboards.


### PR DESCRIPTION
Request PIDs for the two MacroPaw keyboards (cf https://github.com/kodachi614/macropaw/).