### PR TITLE
add 6262 - xwhatsit QMK VIA

### DIFF
--- a/1209/6262/index.md
+++ b/1209/6262/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: xwhatsit capacitive keyboard QMK VIA
+owner: ModelFKeyboard
+license: GPLv2
+site: https://geekhack.org/index.php?topic=58138.0
+source: https://github.com/matthew-wolf-n4mtt/qmk_firmware/tree/model_f_labs_f62_f77/keyboards/model_f_labs/f62
+---


### PR DESCRIPTION
Need a PID because the newest version of VIA does not like the 0xFEED VID.