### PR TITLE
PR for PID E007 for "Exp.007 SECCID"

### DIFF
--- a/1209/E007/index.md
+++ b/1209/E007/index.md
@@ -1,0 +1,11 @@
+---
+layout: E007
+title: Exp.007 SECCID
+owner: vx4.net
+license: GPLv3
+site: https://github.com/VX4/seccid
+source: https://github.com/ckahlo/seccid
+---
+The "Secure Element CCID" connector allows you to connect to secure sensor busses behind an I2C secure element as simple as a smartcard interface on your favourite desktop OS.\
+Because the communication protocol for secure elements is based on ISO7816 and messages to the trusted I2C bus are expressed as ISO7816 APDUs it is convenient to use your favourite programming language, connect to the smartcard (PC/SC) stack on your OS and start talking to your sensors over USB CCID.
+As some OS (Linux / Mac OS) require an individual PID/VID combination to register CCID interfaces correctly and to not confuse it with other uses for the interface this PID was requested.

--- a/1209/E007/index.md
+++ b/1209/E007/index.md
@@ -1,5 +1,5 @@
 ---
-layout: E007
+layout: pid
 title: Exp.007 SECCID
 owner: vx4.net
 license: GPLv3

--- a/org/vx4.net/index.md
+++ b/org/vx4.net/index.md
@@ -1,0 +1,11 @@
+---
+layout: org
+title: VX4.NET / ck@vx4.net
+site: https://vx4.net/
+---
+
+VX4.NET is the organisation I, @ckahlo / Christian Kahlo, am running since around 2004 and most people recognize me behind ck@VX4.\
+Additionally I'm a Chief Security Architect at adesso SE, a pan-european IT and software engineering company originating in Germany.\
+Mostly hardware parts come from specialized manufacturers and vendors, in rare cases we start hardware development on our own.\
+Particularly my focus is on (implementation of) cryptography and secure hardware and software development as well security architecture and secure software development lifecycles. With this focus I'm also working as a contractor for the German Federal Office for Information Security, i.e. for [FIDELIO](https://gitlab.com/adessoAG/FIDELIO/).\
+Recent activities together wih German Aerospace Center [DLR](https://www.dlr.de/en) moved my focus a bit more towards secure embedded sensor networks and secure communication in space. The implemented software in most projects is mainly based on C/C++, JavaCard, Golang or Java.


### PR DESCRIPTION
For this project to function correctly on some OS a dedicated PID is required to be associated with the platform smartcard stack driver manager (on Linux pcscd), so it is recognized and enumerated as USB CCID device. Some more details are explained inside the corresponding description files.