### PR TITLE
Add blus audio usb-i2s bridge

### DIFF
--- a/1209/AF01/index.md
+++ b/1209/AF01/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: USB-I2S bridge
+owner: blus-audio
+license: GPL-3.0 (software), CERN-OHL-S-2.0 (hardware)
+site: https://github.com/blus-audio/firmware
+source: https://github.com/blus-audio/firmware
+---
+A UAC 1.0 compliant USB to I2S bridge (sound card).

--- a/org/blus-audio/index.md
+++ b/org/blus-audio/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: blus-audio
+site: https://github.com/blus-audio
+---
+A collection of open source audio hardware and software.


### PR DESCRIPTION
This is mainly software that runs on STM32 processors, for creating a USB (UAC 1.0 compliant) sound card that outputs audio over I2S: a USB-I2S bridge.

There is compatible hardware, which uses this specific firmware implementation. The github repository for the firmware links to it (and vice-versa).

The firmware: https://github.com/blus-audio/firmware
The hardware: https://github.com/blus-audio/hardware, more specifically https://github.com/blus-audio/hardware/tree/main/blus-mini

I also have a question: Assuming that there will be a future piece of hardware that changes things that are unrelated to the USB-I2S bridge, can the PID still be reused for it? The behaviour with regard to the USB portion, as well as the USB hardware block itself would remain unchanged.