### PR TITLE
request a PID for Riotee Gateway

### DIFF
--- a/1209/C8A2/index.md
+++ b/1209/C8A2/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Riotee gateway
+owner: NessieCircuits
+license: MIT
+site: https://github.com/NessieCircuits/Riotee_Gateway
+source: https://github.com/NessieCircuits/Riotee_Gateway
+---
+The Riotee Gateway communicates with Riotee devices via a proprietary wireless protocol.
+The gateway forwards messages between the devices and a host.
+The firmware runs on a nRF52840-Dongle, a commercial product with open-source hardware design.


### PR DESCRIPTION
The Riotee Gateway forwards messages between Riotee devices and a host application.
The MIT-licensed firmware for which the PID is requested runs on a Nordic Semiconductor nRF52840-Dongle, a third-party commercial product for which schematics and layout are publicly available [here](https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/dev-kits/nrf52840-dongle/nrf52840-usb-dongle---hardware-files-2_1_1.zip).