### PR TITLE
Improve options for RV003USB

### DIFF
--- a/1209/4269/index.md
+++ b/1209/4269/index.md
@@ -1,0 +1,9 @@
++---
++layout: pid
++title: MAGFest 2024 Swadge
++owner: cnlohr
++license: MIT-x11, Public Domain
++site: https://github.com/AEFeinstein/Swadge-IDF-5.0
++---
++The MAGFest Swadge is a hand-held game system / multi-purpose device with an LCD, IMU, buzzers, microphone, touch pad and an ESP32-S2.  This PID is used for debug printf, and sandbox operations.
+

--- a/1209/B003/index.md
+++ b/1209/B003/index.md
@@ -9,4 +9,4 @@ The CH32V003 is a 10 cent microcontroller. RV003USB is a firmware-only USB stack
 
 Provided the bootloader has been installed, this allows you to flash the part without a bootloader.
 
-As a note: Only assume that this device is as intended if the first 4 WCHARs of SERIAL are "BOOT"
+As a note: Please monitor the serial number for further differentiation.

--- a/1209/C003/index.md
+++ b/1209/C003/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: CH32V003 RISC-V USB Generic HID Dongle
+owner: cnlohr
+license: MIT-x11, Public Domain
+site: http://github.com/cnlohr/rv003usb
+---
+The CH32V003 is a 10 cent microcontroller. RV003USB is a firmware-only USB stack for the RISC-V platform.
+
+This is the PID code for HID devices that are **NOT** the bootloader.  And it's intended to be for any of the HID devices, and specific devices will differentiate based on serial.

--- a/1209/D003/index.md
+++ b/1209/D003/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: CH32V003 RISC-V USB Generic Raw Device
+owner: cnlohr
+license: MIT-x11, Public Domain
+site: http://github.com/cnlohr/rv003usb
+---
+The CH32V003 is a 10 cent microcontroller. RV003USB is a firmware-only USB stack for the RISC-V platform.
+
+This is the PID code for totally generic devices that are intended to be communicated to through userspace. Specific devices will differentiate based on serial.

--- a/1209/D003/index.md
+++ b/1209/D003/index.md
@@ -7,4 +7,4 @@ site: http://github.com/cnlohr/rv003usb
 ---
 The CH32V003 is a 10 cent microcontroller. RV003USB is a firmware-only USB stack for the RISC-V platform.
 
-This is the PID code for totally generic devices that are intended to be communicated to through userspace. Specific devices will differentiate based on serial.
+This is the PID code for totally generic devices that are intended to be communicated to through userspace.


### PR DESCRIPTION
It would be really helpful if there were 3 basic devices - a bootloader, a HID descriptor and a generic non-HID descriptor for users.

See more about rv003usb here (also referenced in the changed files): https://github.com/cnlohr/rv003usb

* Update the Bootloader description.
* Add generic HID for rv003usb project.
* Add generic USB device for rv003usb project.