### PR TITLE
Request a VID/PID pair for zynthian USB gadget

### DIFF
--- a/1209/5242/index.md
+++ b/1209/5242/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: zynthian
+owner: zynthian.org
+license: GPLv3
+site: https://zynthian.org
+source: https://github.com/zynthian/zynthian-ui
+---

--- a/1209/5242/index.md
+++ b/1209/5242/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: zynthian
-owner: zynthian.org
+owner: zynthian
 license: GPLv3
 site: https://zynthian.org
 source: https://github.com/zynthian/zynthian-ui

--- a/1209/5242/index.md
+++ b/1209/5242/index.md
@@ -7,3 +7,5 @@ site: https://zynthian.org
 source: https://github.com/zynthian/zynthian-ui
 ---
 Zynthian is an Open Platform for synthesis and audio processing. Hardware is open and software is free as in Freedom.
+Hardware repository is separated from UI: https://github.com/zynthian/zynthian-hw
+You will find all related repos here: https://github.com/zynthian

--- a/1209/5242/index.md
+++ b/1209/5242/index.md
@@ -6,3 +6,4 @@ license: GPLv3
 site: https://zynthian.org
 source: https://github.com/zynthian/zynthian-ui
 ---
+Zynthian is an Open Platform for synthesis and audio processing. Hardware is open and software is free as in Freedom.

--- a/org/zynthian/index.md
+++ b/org/zynthian/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Zynthian
+site: https://zynthian.org/
+---
+Zynthian is an Open Platform for synthesis and audio processing. Hardware design is open and software is free as in Freedom.


### PR DESCRIPTION
A zynthian device can be connected to a laptop or desktop computer, acting as a MIDI-USB compliant device for receiving and sending MIDI data.