### PR TITLE
requesting a PID for retrobeef arcadinator dual joystick

### DIFF
--- a/1209/CADE/index.md
+++ b/1209/CADE/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Arcadinator
+owner: RetroBeef
+license: GPLv2 AND CERN-OHL-S-2.0
+site: https://github.com/RetroBeef
+source: https://github.com/RetroBeef/ArcadinatorV1
+---
+Cheap and open replacement for arcade control panel to usb boards
+

--- a/org/RetroBeef/index.md
+++ b/org/RetroBeef/index.md
@@ -8,5 +8,5 @@ Open source Hardware and Software for retro gaming
 
 ### Licenses
 
-- Software: GPLv2
+- Software: GPLv3
 - Hardware: CERN-OHL-S-2.0

--- a/org/RetroBeef/index.md
+++ b/org/RetroBeef/index.md
@@ -1,0 +1,12 @@
+---
+layout: org
+title: Retrobeef
+site: https://github.com/RetroBeef
+---
+
+Open source Hardware and Software for retro gaming
+
+### Licenses
+
+- Software: GPLv2
+- Hardware: CERN-OHL-S-2.0


### PR DESCRIPTION
Arcadinator is meant to be a cheap and open replacement
for arcade control panel to usb boards like "zero delay usb encoder".
Additionally, Arcadinator supports two players instead of only one and
you can optionally use it wirelessly via NRF24L01.