### PR TITLE
PiKVM pidcodes

### DIFF
--- a/1209/EDA1/index.md
+++ b/1209/EDA1/index.md
@@ -1,11 +1,11 @@
 ---
 layout: pid
-title: Pi-KVM Composite Device
-owner: Pi-KVM
+title: PiKVM Composite Device
+owner: PiKVM
 license: GPLv3
 site: https://pikvm.org
 source: https://github.com/pikvm/pikvm
 ---
-Open and cheap DIY IP-KVM based on Raspberry Pi.
+Open and inexpensive DIY IP-KVM based on Raspberry Pi.
 
 This device can combine HID, Mass Storage, Ethernet-over-USB, and so on.

--- a/1209/EDA2/index.md
+++ b/1209/EDA2/index.md
@@ -1,11 +1,11 @@
 ---
 layout: pid
-title: Pi-KVM HID
-owner: Pi-KVM
+title: PiKVM HID
+owner: PiKVM
 license: GPLv3
 site: https://pikvm.org
 source: https://github.com/pikvm/pikvm
 ---
-Open and cheap DIY IP-KVM based on Raspberry Pi.
+Open and inexpensive DIY IP-KVM based on Raspberry Pi.
 
 Dedicated hardware HID.

--- a/1209/EDA3/index.md
+++ b/1209/EDA3/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: PiKVM HID Bridge
+owner: PiKVM
+license: GPLv3
+site: https://pikvm.org
+source: https://github.com/pikvm/pikvm
+---
+Open and inexpensive DIY IP-KVM based on Raspberry Pi.
+
+USB-to-something (like PS/2) HID bridge.

--- a/org/Pi-KVM/index.md
+++ b/org/Pi-KVM/index.md
@@ -1,6 +1,0 @@
----
-layout: org
-title: Pi-KVM
-site: https://pikvm.org
----
-Open and cheap DIY IP-KVM based on Raspberry Pi

--- a/org/PiKVM/index.md
+++ b/org/PiKVM/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: PiKVM
+site: https://pikvm.org
+---
+Open and inexpensive DIY IP-KVM based on Raspberry Pi


### PR DESCRIPTION
Hello!
* The organization name was changed from `Pi-KVM` to `PiKVM`.
* Requested yet another pid `0xEDA3` for the USB-to-PS/2 bridge converter. Schematics and firmware is open: https://docs.pikvm.org/pico_hid