### PR TITLE
Requesting a PID to be used for a CircuitPython port of the SuperMini NRF52840

### DIFF
--- a/1209/ADF0/index.md
+++ b/1209/ADF0/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SuperMini NRF52840
+owner: Axeia
+license: MIT
+site: https://github.com/MeNeedingADifferentFork/circuitpython-supermini-nrf5284
+source: https://github.com/MeNeedingADifferentFork/circuitpython-supermini-nrf52840
+---
+I do not have access to the board schematic, but there is a wiki page from the manufacturer: http://wiki.icbbuy.com/doku.php?id=developmentboard:nrf52840

--- a/org/Axeia/index.md
+++ b/org/Axeia/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Axeia
+site: https://github.com/Axeia
+---
+I'm just a programmer prodding code for fun, contributing to other projects and sharing my own code.


### PR DESCRIPTION
I do not manufacture or sell the board this PID will be for. Just a hobbyist trying to port CircuitPython to it. Out of the box it seems to use Adafruits VID so I'd like to request a unique PID for this board so I can get it approved for contribution to the CircuitPython github repository.
A pull request for my contribution can be found here:
https://github.com/adafruit/circuitpython/pull/8476