### PR TITLE
MiniDexed

### DIFF
--- a/1209/F043/index.md
+++ b/1209/F043/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: MiniDexed
+site: https://github.com/probonopd/MiniDexed/
+---
+MiniDexed is a FM synthesizer running on Raspberry Pi

--- a/1209/F043/index.md
+++ b/1209/F043/index.md
@@ -1,6 +1,9 @@
 ---
-layout: org
+layout: pid
 title: MiniDexed
+owner: probonopd
+license: GPLv3
 site: https://github.com/probonopd/MiniDexed/
+source: https://github.com/probonopd/MiniDexed/
 ---
 MiniDexed is a FM synthesizer running on Raspberry Pi

--- a/1209/F043/index.md
+++ b/1209/F043/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: MiniDexed
-owner: probonopd
+owner: MiniDexed
 license: GPLv3
 site: https://github.com/probonopd/MiniDexed/
 source: https://github.com/probonopd/MiniDexed/

--- a/org/MiniDexed/index.md
+++ b/org/MiniDexed/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: MiniDexed
+site: https://github.com/probonopd/MiniDexed/
+---
+MiniDexed is a FM synthesizer running on Raspberry Pi


### PR DESCRIPTION
Hi there and thanks for providing this service :+1: 

MiniDexed is a FM synthesizer closely modeled on the famous DX7 by a well-known Japanese manufacturer running on a bare metal Raspberry Pi (without a Linux kernel or operating system). On Raspberry Pi 2 and larger, it can run 8 tone generators, not unlike the TX816/TX802 (8 DX7 instances without the keyboard in one box). [Featured by HACKADAY](https://hackaday.com/2022/04/19/bare-metal-gives-this-pi-some-classic-synths/), [adafruit](https://blog.adafruit.com/2022/04/25/free-yamaha-dx7-synth-emulator-on-a-raspberry-pi/), and [Synth Geekery](https://www.youtube.com/watch?v=TDSy5nnm0jA).

We'd like to use this USB VID/PID to implement a MIDI device as a USB gadget.

Reference:
* https://github.com/probonopd/MiniDexed/issues/547