### PR TITLE
PID request for Chrumm keyboard

### DIFF
--- a/1209/5E7C/index.md
+++ b/1209/5E7C/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Chrumm keyboard
+owner: sev.dev
+license: CERN-OHL-W v2 or later
+site: https://sev.dev/hardware/chrumm-keyboard/
+source: https://github.com/sevmeyer/chrumm-keyboard/
+---

--- a/org/sev.dev/index.md
+++ b/org/sev.dev/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: sev.dev
+site: https://sev.dev/
+---
+Open source enthusiast and maker of peculiar things.


### PR DESCRIPTION
[Chrumm] is a 3D-printed keyboard, with custom PCBs and firmware running on a Raspberry Pi Pico.
All source and release files are licensed under the CERN-OHL-W.

[Chrumm]: https://github.com/sevmeyer/chrumm-keyboard/