### PR TITLE
Requesting PID for 3DP Accelerometer 3dpaxxel

### DIFF
--- a/1209/E11A/index.md
+++ b/1209/E11A/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: 3dpaxxel
+owner: 3dp-accelerometer
+license: Apache-2.0
+site: https://github.com/3dp-accelerometer
+source: https://github.com/3dp-accelerometer/controller
+---

--- a/org/3dp-accelerometer/index.md
+++ b/org/3dp-accelerometer/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: 3DP Accelerometer
+site: https://github.com/3dp-accelerometer
+---
+Controller for 3D printer acting as proxy in between accelerometer and host.


### PR DESCRIPTION
Request PID for the [3DP Accelerometer](https://github.com/3dp-accelerometer) project. 

The project implements an accelerometer controller (FW inclusive host API and [OctoPrint Plugin](https://octoprint.org/)) that can be used to measure the printer's resonance for [input shaping](https://marlinfw.org/docs/gcode/M593.html).