### PR TITLE
Request PID for MAGFest Swadge.

### DIFF
--- a/1209/4269/index.md
+++ b/1209/4269/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: MAGFest 2024 Swadge
+owner: cnlohr
+license: MIT-x11, Public Domain
+site: https://github.com/AEFeinstein/Swadge-IDF-5.0
+---
+
+The MAGFest Swadge is a hand-held game system / multi-purpose device with an LCD, IMU, buzzers, microphone, touch pad and an ESP32-S2.  This PID is used for debug printf, and sandbox operations.
+


### PR DESCRIPTION
The MAGFest Swadge is a hand-held game system / multi-purpose device with an LCD, IMU, buzzers, microphone, touch pad and an ESP32-S2.  This PID is used for HID input, debug printf, and sandbox operations.

This is a request to see if we can get a PID code for it instead of re-using the manufacturer's VID/PID pair.