### PR TITLE
Add flow3r pid codes F103 and F10B

### DIFF
--- a/1209/F103/index.md
+++ b/1209/F103/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: flow3r-firmware
+owner: flow3r
+license: CERN OHL S and GPL v3
+site: https://flow3r.garden
+source: https://git.flow3r.garden/flow3r/
+---
+The main firmware for the flow3r music instrument

--- a/1209/F10B/index.md
+++ b/1209/F10B/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: flow3r-recovery
+owner: flow3r
+license: CERN OHL S and GPL v3
+site: https://flow3r.garden
+source: https://git.flow3r.garden/flow3r/
+---
+The bootloader and recovery environment of the flow3r music instrument

--- a/org/flow3r/index.md
+++ b/org/flow3r/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: flow3r
+site: https://flow3r.garden
+---
+An open source experimental music instrument


### PR DESCRIPTION
flow3r is an open source experimental music instrument.
Hardware repository: https://git.flow3r.garden/flow3r/flow3r-hardware
Licensed under CERN OHL S

Software repository: https://git.flow3r.garden/flow3r/flow3r-firmware
Licensed under GPL v3

We need two PIDs to be able to distinguish easily between the device running normally and being in recovery/bootloader mode, which is a graphical second stage bootloader that allows to do a few low level actions and can receive firmware via USB or mount the user data as mass storage.
In normal operation the main use of the USB interface is accessing the Micropython REPL and doing USB Audio related tasks. Software that looks for VID/PID pairs should not try to grab the device while it is in bootloader mode. Having distinct PIDs solves that.