### PR TITLE
Request PIDs for RF Chameleon

### DIFF
--- a/1209/5F00/index.md
+++ b/1209/5F00/index.md
@@ -1,0 +1,17 @@
+---
+layout: pid
+title: RF Chameleon
+owner: andreas.sandberg.uk
+license: Apache-2.0
+site: https://github.com/rfchameleon
+source: https://github.com/rfchameleon/rfchameleon-fw
+---
+
+RF Chameleon is a set of tools to interface with ISM-band devices. It
+exposes a high-level interface to software by handling low-level
+protocol details, such as RF channels and modulation, in firmware.
+
+The firmware is licensed under the Apache 2.0 license and the
+[custom hardware](https://github.com/rfchameleon/rfchameleon-hw) is
+licensed under the Solderpad Hardware License 2.1 (aka Apache-2.0 WITH
+SHL-2.1).

--- a/org/andreas.sandberg.uk/index.md
+++ b/org/andreas.sandberg.uk/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Andreas Sandberg
+site: https://andreas.sandberg.uk
+---
+
+I build stuff in my spare time.


### PR DESCRIPTION
RF Chameleon is a small tool to interface with ISM-band devices. The tool currently consists of the following parts:

- [Firmware](https://github.com/rfchameleon/rfchameleon-fw) to interface with TI radios (currently only tested with the CC1101).
- A [custom board](https://github.com/rfchameleon/rfchameleon-hw) that can be used instead of a dev-board with a CC1101 module.
- A MCUboot-based bootloader convenient firmware upgrades.

The firmware is licensed under Apache 2.0 and the hardware under the Solderpad Hardware License 2.1 (aka Apache-2.0 WITH SHL-2.1).

This PR requests the following PIDs:

- 0x5F00 for the radio interface.
- ~0x5F01 for the bootloader.~

**Update:** Dropping bootloader PID for now since MCUboot is still WIP and  hasn't been merged into mainline yet. 