### PR TITLE
Request PID 63C1 for GekiPi

### DIFF
--- a/1209/63C1/index.md
+++ b/1209/63C1/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: GekiPi
+owner: ljsebald
+license: MIT + CERN-OHL-S v2
+site: https://github.com/ljsebald/gekipi/
+source: https://github.com/ljsebald/gekipi/
+---
+A USB controller for a certain rhythm game and its workalikes.

--- a/org/ljsebald/index.md
+++ b/org/ljsebald/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: ljsebald
+site: https://github.com/ljsebald
+---
+Hobbyist open-source developer and hardware tinkerer.


### PR DESCRIPTION
GekiPi is a arcade-style controller for rhythm games.

The hardware design/layout is licensed under the CERN-OHL-S v2 and the firmware is licensed under the MIT license.