### PR TITLE
Request PID 0xFF02 for TReK G50 TIJUANA

### DIFF
--- a/1209/FF02/index.md
+++ b/1209/FF02/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: TReK G50 TIJUANA
+owner: digitarhythm
+license: MIT
+site: https://github.com/digitarhythm/tijuana
+source: https://github.com/digitarhythm/tijuana
+---


### PR DESCRIPTION
TReK G50 TIJUANA is 40% keyboard with Tenkey.

KiCAD file and Firmware:
https://github.com/digitarhythm/tijuana