### PR TITLE
PID Code request for Ergodonk split keyboard

### DIFF
--- a/1209/455A/index.md
+++ b/1209/455A/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: ErgoDonk Zero
+owner: JellyTitan
+license: MIT
+site: https://github.com/JellyTitan/ErgoDonk-Zero
+source: https://github.com/JellyTitan/ErgoDonk-Zero
+---
+
+ErgoDonk Zero is a 6×9+6 keys split ortholinear keyboard with encoder, solenoid support, hot-swop sockets for MX or Choc v1 low profile switches, and uses the RP2040 "Zero" MCU.

--- a/1209/455A/index.md
+++ b/1209/455A/index.md
@@ -1,9 +1,9 @@
 ---
 layout: pid
-title: ErgoDonk Zero
+title: ErgoDonk Zero Split Keyboard
 owner: JellyTitan
 license: MIT
-site: https://github.com/JellyTitan/ErgoDonk-Zero
+site: https://www.ergodonk.com
 source: https://github.com/JellyTitan/ErgoDonk-Zero
 ---
 

--- a/org/JellyTitan/index.md
+++ b/org/JellyTitan/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: JellyTitan
+site: https://github.com/JellyTitan
+---
+Individual contributor developing hardware and software, specializing in keyboards.


### PR DESCRIPTION
PID request is for an MIT licensed open-source split ergonomic keyboard.