### PR TITLE
PID for Picuno RP2040

### DIFF
--- a/1209/2024/index.md
+++ b/1209/2024/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: PicUNO RP2040
+owner: AtrivaTECH
+license: MIT, GNU
+site: http://www.atrivatech.com/picuno
+source: http://github.com/atrivatech/picuno
+---

--- a/1209/2024/index.md
+++ b/1209/2024/index.md
@@ -6,3 +6,4 @@ license: MIT, GNU
 site: http://www.atrivatech.com/picuno
 source: http://github.com/atrivatech/picuno
 ---
+The PicUNO is an RP2040 powered UNO form Factor Pico board with level shifting to 5V on certain GPIO compatible with Micro Python, CircuitPython and Arduino IDE (C/C++)

--- a/org/AtrivaTECH/index.md
+++ b/org/AtrivaTECH/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: AtrivaTECH
+site: http://www.atrivatech.com/
+---
+AtrivaTECH established in 2009 has been providing SaaS and HaaS services. Now also assisting with microcontroller development boards and educational tools manufacture and design. 


### PR DESCRIPTION
The PicUNO RP2040 is compatible with MicroPython and Circuit Python. I need the PID code for CircuitPython compatibility. As of now, I have created a custom fork and build for testers to test based on the Metro RP2040's board files. However, if it goes commercial, I will need a custom PID. Complete documentation and such is available. Do revert if queries arise. 
PID 0x2024