### PR TITLE
Update URLs and name for `PassPico` to `passta`

### DIFF
--- a/1209/E128/index.md
+++ b/1209/E128/index.md
@@ -1,8 +1,8 @@
 ---
 layout: pid
-title: PassPico
+title: passta
 owner: brxken128
 license: BSD 2-Clause
-site: https://github.com/brxken128/passpico
-source: https://github.com/brxken128/passpico
+site: https://github.com/brxken128/passta
+source: https://github.com/brxken128/passta
 ---

--- a/org/brxken128/index.md
+++ b/org/brxken128/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
 title: brxken128
-site: https://github.com/brxken128/
+site: https://brxken.dev/
 ---
 a rust OSS developer


### PR DESCRIPTION
This PR adds my personal site ([brxken.dev](https://brxken.dev/)) and updates the URL of the repository, as well as the name of the project as it has since been updated (no boards in production are using the name `PassPico`).

I've decided to move away from the Pi Pico (hence the prior name `PassPico`) and focus on alternative chips and boards that offer higher levels of security, but I still plan to have support for the Pi Pico/RP2040 (just at the user's own risk, unless they add a HSM/cryptographic co-processor, which I'll fully support).