### PR TITLE
Tomato Radio Automation Controller PID

### DIFF
--- a/1209/7111/index.md
+++ b/1209/7111/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Tomato Radio Automation Button Box
+owner: dtcooper
+license: MIT
+site: https://github.com/dtcooper/tomato/blob/main/controller/README.md
+source: https://github.com/dtcooper/tomato/tree/main/controller
+---

--- a/org/dtcooper/index.md
+++ b/org/dtcooper/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: David Cooper
+site: http://github.com/dtcooper
+---
+Physical hardware projects, mostly related to
+[Tomato Radio Automation](https://github.com/dtcooper/tomato/)


### PR DESCRIPTION
Requesting a PID for [Tomato Radio Automation Controller](https://github.com/dtcooper/tomato/tree/main/controller).

This is a simple one-button controller for radio automation software.

## Criteria

 - [x] [Publicly available source code repository](https://github.com/dtcooper/tomato/tree/main/controller))
 - [x] Uses a Raspberry Pi Pico with Circuitpython, which has free/libre "schematics and source code for a device with a USB interface"
 - [x] Has MIT license ([see project LICENSE file here](https://github.com/dtcooper/tomato/blob/main/LICENSE)).