### PR TITLE
Add DMG1083 panel driver as 1209:3706

### DIFF
--- a/1209/3706/index.md
+++ b/1209/3706/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: DMG1083 panel driver
+owner: eta
+license: Apache-2.0
+site: https://eta.st/dmg1083
+source: https://git.eta.st/eta/led-panel-zone
+---

--- a/org/eta/index.md
+++ b/org/eta/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: eta
+site: https://eta.st
+---
+I'm a software engineer and occasional electronics hobbyist. There's more about me on my website!


### PR DESCRIPTION
I've made an open-source driver board ([kicad source](https://git.eta.st/eta/led-panel-zone/-/tree/main/pcbs/rev2?ref_type=heads)) for a range of proprietary ["DMG1083" LED panels](https://led.limehouselabs.org/docs/tiles/dmg1083/).

This VID:PID is for the [usb2panel](https://git.eta.st/eta/led-panel-zone/-/tree/main/usb2panel?ref_type=heads) open-source firmware that runs on this board, which currently uses `cafe:eeee` as a placeholder. Having something a bit more official would really help me out, as other people have expressed interest in having some of the boards made!

Many thanks in advance; please let me know if I've messed something up or you need anything else :)