### PR TITLE
Org/PID request for Tiliqua

### DIFF
--- a/1209/AA61/index.md
+++ b/1209/AA61/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: apfelbug
 owner: apfelaudio
 license: CERN-OHL-S-2.0
-site: https://github.com/apfelaudio/tiliqua
-source: https://github.com/apfelaudio/tiliqua
+site: https://github.com/apfelaudio/apfelbug
+source: https://github.com/apfelaudio/apfelbug
 ---
-`apfelbug` is an RP2040-based JTAG debugger and CDC/UART terminal that is built into the Tiliqua FPGA-based audio multitool. It runs firmware based on the `pico-dirtyJtag` project.
+`apfelbug` is an RP2040-based JTAG debugger and CDC/UART terminal that is built into the Tiliqua FPGA-based audio multitool. It runs firmware based on the `pico-dirtyJtag` project with some additional features.

--- a/1209/AA61/index.md
+++ b/1209/AA61/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: apfelbug
+owner: apfelaudio
+license: CERN-OHL-S-2.0
+site: https://github.com/apfelaudio/tiliqua
+source: https://github.com/apfelaudio/tiliqua
+---
+`apfelbug` is an RP2040-based JTAG debugger and CDC/UART terminal that is built into the Tiliqua FPGA-based audio multitool. It runs firmware based on the `pico-dirtyJtag` project.

--- a/1209/AA61/index.md
+++ b/1209/AA61/index.md
@@ -2,8 +2,8 @@
 layout: pid
 title: apfelbug
 owner: apfelaudio
-license: CERN-OHL-S-2.0
+license: MIT
 site: https://github.com/apfelaudio/apfelbug
 source: https://github.com/apfelaudio/apfelbug
 ---
-`apfelbug` is an RP2040-based JTAG debugger and CDC/UART terminal that is built into the Tiliqua FPGA-based audio multitool. It runs firmware based on the `pico-dirtyJtag` project with some additional features.
+`apfelbug` is an RP2040-based JTAG debugger and CDC/UART terminal that is built into the Tiliqua FPGA-based audio multitool and other devices from apfelaudio. It runs firmware based on the `pico-dirtyJtag` project with some additional features.

--- a/1209/AA62/index.md
+++ b/1209/AA62/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: tiliqua
+owner: apfelaudio
+license: CERN-OHL-S-2.0
+site: https://github.com/apfelaudio/tiliqua
+source: https://github.com/apfelaudio/tiliqua
+---
+Tiliqua is a standalone FPGA-based audio multitool in a Eurorack module. It has 8 proximity-sensitive audio channels, MIDI, USB2 audio capability using the provided high-speed PHY, a built-in debugger and PMOD-compatible expansion headers.
+
+Tiliqua has 2 USB ports: a high-speed USB2 port for class-compliant USB audio (this pid), and a built-in debugger which enumerates as `apfelbug` (separate pid).

--- a/org/apfelaudio/index.md
+++ b/org/apfelaudio/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: apfelaudio
+site: https://www.apfelaudio.com/
+---
+Open audio hardware and FPGA-based tools for musicians and engineers.


### PR DESCRIPTION
Thank you for this wonderful service to the open-hardware community :)

- I have added context as to why 2 PIDs are requested in the markdown itself.
- The hardware and gateware designs can be found in the linked repository.
- OSHWA certification: https://certification.oshwa.org/de000144.html
- ~~You will not find the firmware for the debugger itself linked, as I am simply using the MIT-licensed [`pico-dirtyJtag`](https://github.com/schnommus/tiliqua-debug) project. However, given the Tiliqua RP2040 circuitry is a bit different to the pi-pico, and that I intend to make modifications to this fork in the future, the debugger requires its own PID.~~
  - The firmware for the debugger including added multiboot features is now up @ https://github.com/apfelaudio/apfelbug