### PR TITLE
Gadget Project BLE-to-USB HID bridge

### DIFF
--- a/1209/4B42/index.md
+++ b/1209/4B42/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: HID bridge
+owner: gadgetproject
+license: CC0
+site: https://github.com/gadgetproject/
+source: https://github.com/gadgetproject/hidbridge/
+---
+BLE-to-USB HID bridge device for connecting BLE keyboards to PC BIOS etc.

--- a/org/gadgetproject/index.md
+++ b/org/gadgetproject/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Gadget Project
+site: https://github.com/gadgetproject
+---
+The idea behind Gadget Project is a space to express our creative talents making useful mini-products that can be built or improved by fellow "tinkerers".


### PR DESCRIPTION
* Requesting 1209/4B42 for a BLE keyboard USB dongle