### PR TITLE
Request PID 5801 for Lily58 Lite Rev3

### DIFF
--- a/1209/5801/index.md
+++ b/1209/5801/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Lily58 Lite Rev3
+owner: yuchi
+license: MIT
+site: https://kata0510.github.io/Lily58-Document/
+source: https://github.com/kata0510/Lily58
+---
+Lily58 is 6×4+4keys column-staggered split keyboard.


### PR DESCRIPTION
Lily58 is open source split keyboard.
Lily58 Lite Rev3 uses RP2040-Zero.

PCB Data(KiCAD): https://github.com/kata0510/Lily58/tree/master/Lite_Rev3
Firmware(QMK Firmware): https://github.com/qmk/qmk_firmware/tree/master/keyboards/lily58