### PR TITLE
PID 2596 for VexUF Horus device

### DIFF
--- a/1209/2596/index.md
+++ b/1209/2596/index.md
@@ -4,7 +4,7 @@ title: VexUF horus CDC
 owner: vexuf
 license: Apache 2.0
 site: https://www.vexuf.com/
-source: https://github.com/AlyBadawy/Vexuf
+source: https://github.com/AlyBadawy/VexUF_Horus_fw.git
 ---
 The VexUF series is a collection of versatile devices designed for a variety of
 applications, including data logging, device control, and remote communication

--- a/1209/2596/index.md
+++ b/1209/2596/index.md
@@ -6,3 +6,8 @@ license: Apache 2.0
 site: https://www.vexuf.com/
 source: https://github.com/AlyBadawy/Vexuf
 ---
+The VexUF series is a collection of versatile devices designed for a variety of
+applications, including data logging, device control, and remote communication
+Each device in the series has unique capabilities tailored to different use
+cases.
+

--- a/1209/2596/index.md
+++ b/1209/2596/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: VexUF horus CDC
+owner: vexuf
+license: Apache License
+site: http://www.vexuf.com/
+source: https://github.com/AlyBadawy/Vexuf
+---

--- a/1209/2596/index.md
+++ b/1209/2596/index.md
@@ -2,7 +2,7 @@
 layout: pid
 title: VexUF horus CDC
 owner: vexuf
-license: Apache License
-site: http://www.vexuf.com/
+license: Apache 2.0
+site: https://www.vexuf.com/
 source: https://github.com/AlyBadawy/Vexuf
 ---

--- a/org/vexuf/index.md
+++ b/org/vexuf/index.md
@@ -22,7 +22,3 @@ The "Seth" device (Deprecated) was used as a sensor board to communicate with
 a Raspberry Pi computer directly to give sensor readings via the serial port.
 It was built on a custom Arduino-based board.
 
-### About Aly Badawy
-
-VexUF, is designed by Aly Badawy (Callsign: AL0Y), Aly is a software developer
-and an embedded systems engineer. (more on https://github.com/alybadawy)

--- a/org/vexuf/index.md
+++ b/org/vexuf/index.md
@@ -24,3 +24,4 @@ It was built on a custom Arduino-based board.
 
 site: https://www.vexuf.com/
 source: https://github.com/AlyBadawy/VexUF_Horus_fw.git
+

--- a/org/vexuf/index.md
+++ b/org/vexuf/index.md
@@ -22,3 +22,5 @@ The "Seth" device (Deprecated) was used as a sensor board to communicate with
 a Raspberry Pi computer directly to give sensor readings via the serial port.
 It was built on a custom Arduino-based board.
 
+site: https://www.vexuf.com/
+source: https://github.com/AlyBadawy/VexUF_Horus_fw.git

--- a/org/vexuf/index.md
+++ b/org/vexuf/index.md
@@ -1,0 +1,28 @@
+---
+layout: org
+title: VexUF (Aly Badawy)
+site: http://www.vexuf.com/
+---
+
+The VexUF series is a collection of versatile devices designed for a variety of
+applications, including data logging, device control, and remote communication
+Each device in the series has unique capabilities tailored to different use
+cases.
+
+The various VexUF devices -each named after ancient Egyptian gods- series,
+currently, includes the "Horus" and "Seth" devices.
+
+The "Horus" device is designed to support both Emergency Operations Centers
+(EOCs) and amateur radio operators in monitoring and managing various power
+sources and environmental conditions. It is engineered to enhance operational
+capabilities by ensuring real-time monitoring of critical parameters, and
+immediate response to a set of custom triggers and actuators.
+
+The "Seth" device (Deprecated) was used as a sensor board to communicate with
+a Raspberry Pi computer directly to give sensor readings via the serial port.
+It was built on a custom Arduino-based board.
+
+### About Aly Badawy
+
+VexUF, is designed by Aly Badawy (Callsign: AL0Y), Aly is a software developer
+and an embedded systems engineer. (more on https://github.com/alybadawy)


### PR DESCRIPTION
This PR is to request PID 2596 for the VexUF Horus device.

The "Horus" device is designed to support both Emergency Operations Centers (EOCs) and amateur radio operators in monitoring and managing various power sources and environmental conditions. It is engineered to enhance operational capabilities by ensuring real-time monitoring of critical parameters.

Horus provides detailed insights into power supply statuses and environmental conditions, ensuring operational continuity and situational awareness. Additionally, the device logs data to an SD card for future retrieval and analysis. The VexUF:Horus supports communication with a computer or a stand-alone TNC, utilizing the APRS protocol to transmit vital information to remote locations. This ensures better coordination and response during emergencies and day-to-day operations for amateur radio enthusiasts.

VexUF Horus is an open source project licensed under the Apache License 2.0.

site: https://www.vexuf.com/
source: https://github.com/AlyBadawy/VexUF_Horus_fw.git