### PR TITLE
Request PID 6804

### DIFF
--- a/1209/6804/index.md
+++ b/1209/6804/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: Hootswitch
+owner: saybur
+license: GPLv3 (firmware), CERN-OHL-S-2.0 (hardware)
+site: https://github.com/saybur/hootswitch
+source: https://github.com/saybur/hootswitch
+---

--- a/1209/6804/index.md
+++ b/1209/6804/index.md
@@ -6,3 +6,4 @@ license: GPLv3 (firmware), CERN-OHL-S-2.0 (hardware)
 site: https://github.com/saybur/hootswitch
 source: https://github.com/saybur/hootswitch
 ---
+ADB keyboard/mouse switch for vintage Mac computers.

--- a/org/saybur/index.md
+++ b/org/saybur/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: saybur
+site: https://www.github.com/saybur
+---
+Retro hardware is best hardware.


### PR DESCRIPTION
Requesting a PID for Hootswitch, an open hardware/firmware peripheral switcher for old Mac computers. Firmware is GPLv3, hardware is CERN-OHL-S-2.0.