### PR TITLE
Request PID 2350 for CircuitArt RP2350 zero 

### DIFF
--- a/1209/2350/index.md
+++ b/1209/2350/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: CircuitArt RP2350 zero
+owner: CircuitArt
+license: MIT
+site: https://github.com/CircuitART/RP2350zero
+source: https://github.com/CircuitART/RP2350zero
+---

--- a/1209/2350/index.md
+++ b/1209/2350/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: CircuitArt RP2350 zero
-owner: CircuitArt
+owner: circuitart
 license: MIT
 site: https://github.com/CircuitART/RP2350zero
 source: https://github.com/CircuitART/RP2350zero

--- a/org/circuitart/index.md
+++ b/org/circuitart/index.md
@@ -3,4 +3,4 @@ layout: org
 title: CircuitArt
 site: https://github.com/CircuitART
 ---
-open source dev boards
+Open-source dev boards

--- a/org/circuitart/index.md
+++ b/org/circuitart/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
-title: joric
+title: CircuitArt
 site: https://github.com/CircuitART
 ---
 open source dev boards

--- a/org/circuitart/index.md
+++ b/org/circuitart/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: joric
+site: https://github.com/CircuitART
+---
+open source dev boards


### PR DESCRIPTION
CircuitArt RP2350 zero is an open-source dev board, based on the RP2350 Microcontroller 

PCB Data(Altium): https://github.com/CircuitART/RP2350zero/tree/main/HRW