### PR TITLE
[Change] VR61 Keyboard (License)

### DIFF
--- a/1209/7672/index.md
+++ b/1209/7672/index.md
@@ -2,8 +2,8 @@
 layout: pid
 title: VR61 Keyboard
 owner: Tecsmith
-license: GPL-3.0
+license: CC BY-SA 4.0
 site: https://c1k.it.vr61
 source: https://github.com/tecsmith/vr61-keyboard-pcb
 ---
-A 61-key "poker" loayout keyboard designed to fit some GH60 cases and features a pluggable SparkFun MicroMod MCU module running QMK firmware.
+A 61-key "poker" loayout keyboard designed to fit GH60 cases and features a pluggable SparkFun MicroMod MCU module running QMK firmware.

--- a/1209/7672/index.md
+++ b/1209/7672/index.md
@@ -2,7 +2,8 @@
 layout: pid
 title: VR61 Keyboard
 owner: Tecsmith
-license: MIT
-site: https://tecsmith.com.au
-source: https://github.com/Tecsmith/vr61-keyboard-pcb
+license: GPL-3.0
+site: https://c1k.it.vr61
+source: https://github.com/tecsmith/vr61-keyboard-pcb
 ---
+A 61-key "poker" loayout keyboard designed to fit some GH60 cases and features a pluggable SparkFun MicroMod MCU module running QMK firmware.


### PR DESCRIPTION
 Update to VR61 Keyboard
- Licence; aligning to SparkFun MicroMod's CC BY-SA 4.0 licence.
- URL change
- Added description line
