### PR TITLE
Request PID  3249 for USB MIDI to Sync Converter

### DIFF
--- a/1209/3249/index.md
+++ b/1209/3249/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: USB MIDI to Sync Converter
+owner: Akagawa Multimedia Laboratory
+license: GPLv3
+site: https://github.com/YuuichiAkagawa/USBMIDItoSyncConverter
+source: https://github.com/YuuichiAkagawa/USBMIDItoSyncConverter
+---
+Converts USB MIDI clock messages to sync signals

--- a/1209/3249/index.md
+++ b/1209/3249/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: USB MIDI to Sync Converter
-owner: Akagawa Multimedia Laboratory
+owner: ammlab.org
 license: GPLv3
 site: https://github.com/YuuichiAkagawa/USBMIDItoSyncConverter
 source: https://github.com/YuuichiAkagawa/USBMIDItoSyncConverter

--- a/org/ammlab.org/index.md
+++ b/org/ammlab.org/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
-title: Akagawa Multimedia Laboratory
+title: ammlab.org
 site: https://ammlab.org
 ---
 An open source synchronizer for electronic musical instruments

--- a/org/ammlab.org/index.md
+++ b/org/ammlab.org/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Akagawa Multimedia Laboratory
+site: https://ammlab.org
+---
+An open source synchronizer for electronic musical instruments
+


### PR DESCRIPTION
Requesting a PID for USB MIDI to Sync Converter, an open hardware/firmware synchronizer for electronic musical instruments.
