### PR TITLE
Request PID FAD1 for 16nx Faderbank.

### DIFF
--- a/1209/FAD1/index.md
+++ b/1209/FAD1/index.md
@@ -1,0 +1,14 @@
+---
+layout: pid
+title: 16nx
+owner: oxion
+license: MIT, CC BY-SA 4.0
+site: https://16n-faderbank.github.io/16nx
+source: https://github.com/16n-faderbank/16next_firmware
+---
+
+16nx is an open-source controller for electronic musical instruments and devices. 16 60mm faders let you control devices over MIDI, CV, and I2C.
+
+[Hardware repo, CC-BY-SA licensed, is here](https://github.com/16n-faderbank/16nx)
+
+[Software repo, MIT licensed, is here](https://github.com/16n-faderbank/16next_firmware)

--- a/org/oxion/index.md
+++ b/org/oxion/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: Oxion
+site: https://16n-faderbank.github.io
+---
+
+Oxion is a not--quite-brand-name for a range of MIDI and musical controllers.
+
+(Named, of course, for the first product, 16n: `0x10n`)


### PR DESCRIPTION
Added org page for a holding org, and a PID page for the 16nx Faderbank. The firmware and hardware are currently in separate repos, as the firmware may be used for other devices in future; I've included a link to both in the PID pages. (If it is, build process will ensure appropriate PID codes are used).