### PR TITLE
Requst PID 1209:CA02 for the CANnectivity USB to CAN adapter DFU firmware

### DIFF
--- a/1209/CA02/index.md
+++ b/1209/CA02/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: USB to CAN adapter (DFU)
+owner: CANnectivity
+license: Apache-2.0
+site: https://github.com/CANnectivity/cannectivity
+source: https://github.com/CANnectivity/cannectivity
+---
+CANnectivity is an open source firmware for Universal Serial Bus (USB)
+to Controller Area Network (CAN) adapters.
+
+The firmware has the capability of being upgraded via USB Device
+Firmware Upgrade (DFU) mode.


### PR DESCRIPTION
The CANnectivity USB to CAN adapter firmware, which uses 1209:CA01, has the capability of being updated via USB Device Firmware Upgrade (DFU) mode.

This requires a separate USB PID in order not to load the regular USB to CAN adapter driver when booted in DFU mode.