### PR TITLE
Request PID 4D6A for Samisara

### DIFF
--- a/1209/4D6A/index.md
+++ b/1209/4D6A/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Samisara
+owner: KeirFraser
+license: Unlicense
+site: http://github.com/keirf/samisara
+source: http://github.com/keirf/samisara
+---
+Samisara is a configurable bridge from retro peripherals to USB HID.


### PR DESCRIPTION
Samisara is a generic configurable USB bridge for retro peripherals (keyboards, joysticks, etc). It is looking for a PID.

The project is "Unlicense", like my other projects, and it lives on GitHub: http://github.com/keirf/samisara