### PR TITLE
add PID for ECCN M0

### DIFF
--- a/1209/5687/index.md
+++ b/1209/5687/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: ECCN M0
-owner: Bradán Lane STUDIO
+owner: Bradán.Lane.STUDIO
 license: MIT
 site: https://bradanlane.com/
 source: https://gitlab.com/bradanlane/eccn_m0

--- a/1209/5687/index.md
+++ b/1209/5687/index.md
@@ -6,4 +6,4 @@ license: MIT
 site: https://bradanlane.com/
 source: https://gitlab.com/bradanlane/eccn_m0
 ---
-A short description of my device and what it does.
+The ECCN M0 is a small SAMD21G18 design with 4MB flash, touch pads, LEDs, and a buzzer. It supports both C/C++ and CircuitPython. An example use for teh the ECCN M0 would be a 3-button macropad.

--- a/1209/5687/index.md
+++ b/1209/5687/index.md
@@ -6,4 +6,4 @@ license: MIT
 site: https://gitlab.com/bradanlane/eccn_m0
 source: https://github.com/bradanlane/circuitpython/tree/bls_coin_m0
 ---
-The ECCN M0 is a small SAMD21G18 design with 4MB flash, touch pads, LEDs, and a buzzer. It supports both C/C++ and CircuitPython. An example use for teh the ECCN M0 would be a 3-button macropad.
+The ECCN M0 is a small SAMD21G18 design with 4MB flash, touch pads, LEDs, and a buzzer. It supports both C/C++ and CircuitPython. An example use for the the ECCN M0 would be a 3-button macropad.

--- a/1209/5687/index.md
+++ b/1209/5687/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: ECCN M0
+owner: Bradán Lane STUDIO
+license: MIT
+site: https://bradanlane.com/
+source: https://gitlab.com/bradanlane/eccn_m0
+---
+A short description of my device and what it does.

--- a/1209/5687/index.md
+++ b/1209/5687/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: ECCN M0
 owner: Bradán.Lane.STUDIO
 license: MIT
-site: https://bradanlane.com/
-source: https://gitlab.com/bradanlane/eccn_m0
+site: https://gitlab.com/bradanlane/eccn_m0
+source: https://github.com/bradanlane/circuitpython/tree/bls_coin_m0
 ---
 The ECCN M0 is a small SAMD21G18 design with 4MB flash, touch pads, LEDs, and a buzzer. It supports both C/C++ and CircuitPython. An example use for teh the ECCN M0 would be a 3-button macropad.

--- a/org/Bradán.Lane.STUDIO/index.md
+++ b/org/Bradán.Lane.STUDIO/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Bradán Lane STUDIO
+site: https://bradanlane.com/
+---
+Bradán Lane STUDIO is a single person lab creating electronics - primarily electronic badges, puzzles, and products which use CircuitPython for easy programming and customization.

--- a/org/bradán.lane.studio/index.md
+++ b/org/bradán.lane.studio/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Bradán Lane STUDIO
+site: https://bradanlane.com/
+---
+Bradán Lane STUDIO is a single person lab creating electronics - primarily electronic badges, puzzles, and products which use CircuitPython for easy programming and customization.

--- a/org/bradán.lane.studio/index.md
+++ b/org/bradán.lane.studio/index.md
@@ -1,6 +1,0 @@
----
-layout: org
-title: Bradán Lane STUDIO
-site: https://bradanlane.com/
----
-Bradán Lane STUDIO is a single person lab creating electronics - primarily electronic badges, puzzles, and products which use CircuitPython for easy programming and customization.


### PR DESCRIPTION
The Bradán Lane STUDIO has created a small PCB using the SAMD21G18 with 4MB of extra flash memory (intended for application data or for CircuitPython code and libraries). It also contains touch pads, a buzzer, and LEDs.

The design is suitable for created a macropad or a small game.

This pull request is to provide a PID for the ECCN M0 for both C/C++ programming and CircuitPython.