### PR TITLE
Request PID for the Tic-Nic PTP Adapter device

### DIFF
--- a/1209/8851/index.md
+++ b/1209/8851/index.md
@@ -1,0 +1,26 @@
+---
+layout: pid
+title: The Tic-Nic PTP Adapter with GPS and Hardware I/O
+owner: till-s
+license: EUPL
+site: https://www.github.com/till-s/tic-nic
+source: https://www.github.com/till-s/tic-nic
+---
+The Tic-Nic is based on the DP83640 PHY with IEEE-1588 (PTP)
+support. The PHY has several hardware GPIOs which can be used to
+capture or generate PTP-synchronized events. These are routed
+to connectors and pins on the board.
+
+A USB CDC-NCM network adapter which connects to the PHY is
+implemented in a Trion-T20 FPGA.
+
+The FPGA has plenty of resources for added user functionality
+(but the device operates just fine as-is).
+
+The board also features an optional GPS receiver which lets you
+operate in PTP grand-master mode. The NMEA data are accessible
+via a USB CDC-ACM interface.
+
+The DP83640 is well-supported under linux; a kernel driver
+which extends the vanilla CDC-NCM driver to integrate PHY
+access via MDIO is part of this project (GPL).

--- a/org/till-s/index.md
+++ b/org/till-s/index.md
@@ -1,0 +1,11 @@
+---
+layout: org
+title: Till's USB Gadgets
+site: https://www.github.com/till-s
+---
+I got interested in FPGAs several years ago and thought that having
+an open-source USB-2.0 device implementation is very handy for building
+hobby projects.
+
+My designs are based on https://www.github.com/till-s/mecatica-usb/
+


### PR DESCRIPTION
While the device mostly is supported by generic CDC-ACM and CDC-NCM class drivers there is some special functionality (supported by vendor-specific control requests) which make it desirable to have a unique PID to  seamlessly bind to the correct driver (which is also part of this project).