### PR TITLE
Request PID 7691, 7692, 7693 for SlimeNRF devices

### DIFF
--- a/1209/7691/index.md
+++ b/1209/7691/index.md
@@ -4,6 +4,6 @@ title: SlimeNRF Receiver Bootloader
 owner: SlimeVR
 license: MIT OR Apache-2.0
 site: https://github.com/SlimeVR/SlimeNRF-Receiver
-source: https://github.com/SlimeVR/SlimeNRF-Receiver
+source: https://github.com/SlimeVR/Adafruit_nRF52_Bootloader
 ---
 UF2 bootloader for SlimeVR receiver

--- a/1209/7691/index.md
+++ b/1209/7691/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SlimeNRF Receiver Bootloader
+owner: SlimeVR
+license: MIT OR Apache-2.0
+site: https://github.com/SlimeVR/SlimeNRF-Receiver
+source: https://github.com/SlimeVR/SlimeNRF-Receiver
+---
+UF2 bootloader for SlimeVR receiver

--- a/1209/7692/index.md
+++ b/1209/7692/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SlimeNRF Tracker
+owner: SlimeVR
+license: MIT OR Apache-2.0
+site: https://github.com/SlimeVR/SlimeNRF-Tracker
+source: https://github.com/SlimeVR/SlimeNRF-Tracker
+---
+SlimeVR smol rotation-based vr trackers

--- a/1209/7693/index.md
+++ b/1209/7693/index.md
@@ -4,6 +4,6 @@ title: SlimeNRF Tracker Bootloader
 owner: SlimeVR
 license: MIT OR Apache-2.0
 site: https://github.com/SlimeVR/SlimeNRF-Tracker
-source: https://github.com/SlimeVR/SlimeNRF-Tracker
+source: https://github.com/SlimeVR/Adafruit_nRF52_Bootloader
 ---
 UF2 bootloader for SlimeVR smol slime

--- a/1209/7693/index.md
+++ b/1209/7693/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: SlimeNRF Tracker Bootloader
+owner: SlimeVR
+license: MIT OR Apache-2.0
+site: https://github.com/SlimeVR/SlimeNRF-Tracker
+source: https://github.com/SlimeVR/SlimeNRF-Tracker
+---
+UF2 bootloader for SlimeVR smol slime


### PR DESCRIPTION
Add bootloader PID for previous SlimeNRF Receiver (7690) and PIDs for tracker device and tracker bootloader
Hardware designs at:
https://github.com/SlimeVR/SlimeNRF-PCB
https://oshwlab.com/sctanf/slimenrf3