### PR TITLE
Requst PID 1209:B001 for the Zephyr based GRUB boot selector switch

### DIFF
--- a/1209/B001/index.md
+++ b/1209/B001/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Zephyr based GRUB boot selector switch
+owner: pkoscik
+license: Apache-2.0
+site: https://github.com/pkoscik/grub-bootsel-zephyr
+source: https://github.com/pkoscik/grub-bootsel-zephyr
+---
+A Zephyr RTOS-based application for selecting GRUB bootloader entries.

--- a/org/pkoscik/index.md
+++ b/org/pkoscik/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: pkoscik
+site: https://blog.pkoscik.net
+---
+Engineer and hobbyist, specializing in bug creation during my free time.


### PR DESCRIPTION
[grub-bootsel-zephyr](https://github.com/pkoscik/grub-bootsel-zephyr) is a Zephyr RTOS based firmware for selecting the GRUB bootloader entry to boot.

Currently, it supports Raspberry Pi Pico and Raspberry Pi Pico W hardware boards, but the firmware itself is target-independent.

Source code is licensed under the [Apache-2.0](https://github.com/pkoscik/grub-bootsel-zephyr/blob/main/LICENSE)