### PR TITLE
Request PID 1209:1445 for the openrobots tk3-paparazzi firmware

### DIFF
--- a/1209/1445/index.md
+++ b/1209/1445/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: tk3-paparazzi
+owner: openrobots
+license: BSD
+site: https://git.openrobots.org/projects/tk3-paparazzi
+source: https://git.openrobots.org/projects/tk3-paparazzi/repository
+---
+Custom firmware for the
+[Paparazzi](https://wiki.paparazziuav.org/wiki/Category:Autopilots) boards
+used in the Aerial Robotics Testbed at [LAAS/CNRS](https://www.laas.fr)

--- a/org/openrobots/index.md
+++ b/org/openrobots/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Openrobots
+site: https://git.openrobots.org
+---
+Openrobots is a collection of free and opensource software for autonomous
+robots developed at [LAAS/CNRS](https://www.laas.fr).


### PR DESCRIPTION
This is a request for custom firmware for the [Paparazzi](https://wiki.paparazziuav.org/wiki/Category:Autopilots) boards used in the Aerial Robotics Testbed at [LAAS/CNRS](https://www.laas.fr)
