### PR TITLE
Request PID 1209:FD42 for CircuitPython on SAO Digital Multimeter

### DIFF
--- a/1209/FD42/index.md
+++ b/1209/FD42/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: SAO Digital Multimeter
+owner: HXR.DK
+license: CC-BY-SA (hardware), MIT (Circuit Python firmware)
+site: https://github.com/flummer/dmm-sao
+source: https://github.com/flummer/dmm-sao
+---
+A small digital multimeter that is designed as a badge add-on, following the SAO v1.69 specification. It is using the Raspberry Pi RP2040 and features a small OLED screen, rotating knob, function button and probe terminals, all housed in a 3D printed case.
+
+The firmware is using CircuitPython and the code can easily be hacked, by connecting via USB-C to the RP2040.

--- a/org/HXR.DK/index.md
+++ b/org/HXR.DK/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: HXR.DK
+site: https://hxr.dk/
+---
+Different projects designed by Thomas Flummer, mostly electronics but also a few other things


### PR DESCRIPTION
This is for CircuitPython on the [SAO Digital Multimeter](https://github.com/flummer/dmm-sao) based on RP2040

Hardware is CC-BY-SA (electronics and 3D printable parts), firmware (CircuitPython and application code) is MIT

[CircuitPython branch for SAO Digital Multimeter](https://github.com/flummer/circuitpython/tree/hxr-sao-dmm) that will use the PID (also linked from the readme on the main project)