### PR TITLE
Request PID 1209:5C51 for BlueSCSI

### DIFF
--- a/1209/5C51/index.md
+++ b/1209/5C51/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: BlueSCSI V2
+owner: BlueSCSI
+license: GPL3
+site: https://bluescsi.com
+source: https://github.com/BlueSCSI/BlueSCSI-V2
+---
+An open source SCSI adapter for connecting modern hardware to vintage computer hardware.

--- a/org/BlueSCSI/index.md
+++ b/org/BlueSCSI/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: BlueSCSI
+site: https://BlueSCSI.com
+---
+The BlueSCSI gang develops an open source SCSI emulator for use with vintage computers.


### PR DESCRIPTION
Added BlueSCSI v2, which is an open source SCSI emulator based upon the Raspberrry Pi Pico (RP2040).

Thank you pidcodes for providing this awesome service to the open source community!