### PR TITLE
Add org:mutenix and pid:2099 for mutenix macroboard

### DIFF
--- a/1209/2099/index.md
+++ b/1209/2099/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Mutenix Macropad
+owner: mutenix
+license: MIT
+site: https://mutenix.de
+source: https://github.com/mutenix-org/firmware-macroboard/
+---
+A simple and stupid macroboard. Basically a keyboard but using a custom HID class to perform tasks in the background.
+It is based on CircuitPython running on either a RPi2040 or for wireless connection on a SuperMini/ProMini NRF52840 or Nice!Nano. The logic is all implemented in the host software for maximum flexibility.
+The current hardware design is also available on [GitHub](https://github.com/mutenix-org/hardware-macroboard).

--- a/org/mutenix/index.md
+++ b/org/mutenix/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: mutenix
+site: https://mutenix.de/
+---
+Macroboards for online meetings. Mute yourself and more.
+


### PR DESCRIPTION
Mutenix Macroboard is a basically a keyboard that uses a non keyboard HID usage id. It requires a host application (https://github.com/mutenix-org/software-host) to perform configurable tasks. It's main or original focus is to mute/unmute yourself in online meetings.