### PR TITLE
Pinscape Pico

### DIFF
--- a/1209/EAEB/index.md
+++ b/1209/EAEB/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Pinscape Pico
+title: Pico Controller
 owner: Pinscape
 license: MIT
 site: https://github.com/mjrgh/PinscapePico/

--- a/1209/EAEB/index.md
+++ b/1209/EAEB/index.md
@@ -1,0 +1,17 @@
+---
+layout: pid
+title: Pinscape Pico
+owner: Pinscape
+license: MIT
+site: https://github.com/mjrgh/PinscapePico/
+source: https://github.com/mjrgh/PinscapePico/
+---
+Pinscape Pico is a comprehensive I/O controller for virtual pinball cabinets
+that runs on the Rasbperry Pi Pico (RP2040).  This project is a sequel to the
+original Pinscape KL25Z controller, reimplemented from the ground up for the
+Pico.  It creates a bridge between virtual pinball software on a PC (such as
+Visual Pinball) and the physical input and output devices commonly found in
+virtual pin cabs, including button inputs, plunger sensor inputs, accelerometer
+(for nudge sensing), and feedback-effect devices (lights, solenoids, motors,
+etc).  The Pico communicates with host software on the PC via USB, using a
+variety of standard HID interfaces and custom application-specific interfaces.

--- a/1209/EAEB/index.md
+++ b/1209/EAEB/index.md
@@ -16,5 +16,5 @@ virtual pin cabs, including button inputs, plunger sensor inputs, accelerometer
 etc).  The Pico communicates with host software on the PC via USB, using a
 variety of standard HID interfaces and custom application-specific interfaces.
 The project includes firmware for the Pico, plus a set of circuit board designs
-for "expansion board" that supplement the Pico's I/O capabilities with added
+for "expansion boards" that supplement the Pico's I/O capabilities with added
 input ports and high-current output ports for feedback devices.

--- a/1209/EAEB/index.md
+++ b/1209/EAEB/index.md
@@ -15,3 +15,6 @@ virtual pin cabs, including button inputs, plunger sensor inputs, accelerometer
 (for nudge sensing), and feedback-effect devices (lights, solenoids, motors,
 etc).  The Pico communicates with host software on the PC via USB, using a
 variety of standard HID interfaces and custom application-specific interfaces.
+The project includes firmware for the Pico, plus a set of circuit board designs
+for "expansion board" that supplement the Pico's I/O capabilities with added
+input ports and high-current output ports for feedback devices.


### PR DESCRIPTION
Request to assign PID EAEB to Pinscape Pico (sequel to the original KL25Z Pinscape, at PID EAEA).  This project shares its name with the KL25Z version, but it's original software with a new set of application-specific USB interfaces, so it needs a unique ID so that host software doesn't misidentify it as the KL25Z project.