### PR TITLE
Reserving PID CCCC for the zeptoforth CDC Console

### DIFF
--- a/1209/CCCC/index.md
+++ b/1209/CCCC/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: CDC Console
+title: zeptoforth CDC Console
 owner: zeptoforth
 license: MIT
 site: https://github.com/tabemann/zeptoforth/

--- a/1209/CCCC/index.md
+++ b/1209/CCCC/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: zeptoforth CDC Console
+title: CDC Console
 owner: zeptoforth
 license: MIT
 site: https://github.com/tabemann/zeptoforth/

--- a/1209/CCCC/index.md
+++ b/1209/CCCC/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: zeptoforth CDC Console
+owner: zeptoforth
+license: MIT
+site: https://github.com/tabemann/zeptoforth/
+source: https://github.com/tabemann/zeptoforth/
+---
+zeptoforth is a FLOSS Forth compiler and operating system for ARM Cortex-M microcontrollers.
+

--- a/org/zeptoforth/index.md
+++ b/org/zeptoforth/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: zeptoforth
+site: http://github.com/tabemann/zeptoforth/
+---
+zeptoforth is a project for the development of a FLOSS Forth compiler and operating system for ARM Cortex-M microcontrollers.


### PR DESCRIPTION
Reserving PID CCCC for the zeptoforth CDC Console