### PR TITLE
Request PID F666 for my USB to EPROM+ adapter.

### DIFF
--- a/1209/F666/index.md
+++ b/1209/F666/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: PEP
+owner: keshbach
+license: Apache 2.0
+site: https://github.com/keshbach/PEP
+source: https://github.com/keshbach
+---
+USB adapter to the EPROM+ System from Andromeda Research Labs.

--- a/org/keshbach/index.md
+++ b/org/keshbach/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Kevin Eshbach
+site: https://github.com/keshbach
+---
+An open-source unofficial Windows application and USB adapter for the EPROM+ System from Andromeda Research Labs.


### PR DESCRIPTION
Request PID F666 for my USB to EPROM+ adapter.