### PR TITLE
Allocate a VID:PID of 1209:BC01 to kearney.dev fat8

### DIFF
--- a/1209/BC01/index.md
+++ b/1209/BC01/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: fat8
-owner: kearney.org
+owner: kearney.dev
 license: BSD + CERN-OHL
 site: https://github.com/jkearneyma/fat8
 source: https://github.com/jkearneyma/fat8

--- a/1209/BC01/index.md
+++ b/1209/BC01/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: fat8
+owner: kearney.org
+license: BSD + CERN-OHL
+site: https://github.com/jkearneyma/fat8
+source: https://github.com/jkearneyma/fat8
+---
+A tiny Intel 8008-based computer capable of running most existing 8008 software and with expansion capabilities.
+

--- a/org/kearney.dev/index.md
+++ b/org/kearney.dev/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: kearney.dev
+---
+Open source hardware and software, mostly focused on retro/vintage activities of one sort or another.


### PR DESCRIPTION
Allocate a VID:PID of 1209:BC01 to the open-source fat8 project: https://github.com/jkearneyma/fat8