### PR TITLE
Add two devices: A001 and A002

### DIFF
--- a/1209/A001/index.md
+++ b/1209/A001/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: PostalPoint Kiosk Controller
+owner: PostalPortal
+license: BSD software/CC-BY-SA 4.0 hardware
+site: https://postalpoint.app/hardware
+source: https://source.netsyms.com/PostalPortal/PostalPoint_Hardware
+---
+Device that enables software to control and monitor a secure parcel drop and unlock it when authorized by a postal worker.

--- a/1209/A002/index.md
+++ b/1209/A002/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: PostalPoint Parcel Dimensioner
+owner: PostalPortal
+license: BSD software/CC-BY-SA 4.0 hardware
+site: https://postalpoint.app/hardware
+source: https://source.netsyms.com/PostalPortal/PostalPoint_Hardware
+---
+Low-cost parcel dimensioner that uses ultrasonic or laser rangefinders for measuring
+the size of a cuboid, streaming measurements to a connected computer via USB HID.

--- a/org/PostalPortal/index.md
+++ b/org/PostalPortal/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: PostalPortal LLC d.b.a PostalPoint®
+site: https://postalportal.net
+---
+Building shipping and postal software for the 21st century.  https://postalpoint.app/hardware


### PR DESCRIPTION
These two devices provide solutions to small businesses for problems that normally cost at least 10x the price to solve, due to industry stagnation and monopolistic tactics.  Two PIDs are being requested because the devices are likely to be used at the same time on the same computer and have similar protocols and ID strings, which could easily cause confusion and result in the wrong device being targeted if they share a PID.

The hardware schematics and the code that runs on the microcontrollers are both open source.  Hardware schematics are only currently available for one device (the kiosk controller). This is because PCBs haven't been designed for the other device (the dimensioner) because currently the prototype schematic is one sensor, three wires, and a Pi Pico, and the details of that sensor and the wiring is described in the source code.

They're designed to work with a particular software system that currently isn't open source because of NDAs, but the devices implement the USB HID protocol so support can be easily added to other software as well.