### PR TITLE
Adding blueTag

### DIFF
--- a/1209/A0D1/index.md
+++ b/1209/A0D1/index.md
@@ -6,4 +6,4 @@ license: MIT
 site: https://github.com/Aodrulez/blueTag
 source: https://github.com/Aodrulez/blueTag/src
 ---
-JTAGulator alternative & a hardware hacker's multi-tool for RP2040 microcontroller based development boards.
+JTAGulator alternative & a hardware hacker's multi-tool for RP2040 microcontroller based development boards. 

--- a/1209/A0D1/index.md
+++ b/1209/A0D1/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: blueTag
+owner: Aodrulez
+license: MIT
+site: https://github.com/Aodrulez/blueTag
+source: https://github.com/Aodrulez/blueTag/src
+---
+JTAGulator alternative & a hardware hacker's multi-tool for RP2040 microcontroller based development boards.

--- a/org/Aodrulez/index.md
+++ b/org/Aodrulez/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Aodrulez
+site: https://github.com/Aodrulez
+---
+Aodrulez is a hardware hacker and an information security researcher, crafting open-source tools for embedded systems, security, and custom electronics.


### PR DESCRIPTION
Adding "blueTag", a JTAGulator alternative & a hardware hacker's multi-tool for RP2040 microcontroller based development boards to the list. Requesting PID: A0D1