### PR TITLE
Add Mathpad by Summa Cogni

### DIFF
--- a/1209/2211/index.md
+++ b/1209/2211/index.md
@@ -1,0 +1,14 @@
+---
+layout: pid
+title: Mathpad
+owner: Summa-Cogni
+license: GNU General Public License v3 and CERN-OHL-S v2
+site: http://www.summacogni.com/Mathpad
+source: https://github.com/Summa-Cogni/Mathpad
+---
+
+Mathpad is a keypad for students and professionals in any STEM field. 
+Mathpad allows for effortless typing of mathematical symbols and equations across applications and operating systems.
+
+Mathpad's firmware is built on QMK and licensed under GNU General Public License v3. 
+Its hardware is licensed under CERN-OHL-S v2

--- a/1209/2211/index.md
+++ b/1209/2211/index.md
@@ -12,3 +12,5 @@ Mathpad allows for effortless typing of mathematical symbols and equations acros
 
 Mathpad's firmware is built on QMK and licensed under GNU General Public License v3. 
 Its hardware is licensed under CERN-OHL-S v2
+
+Mathpad is OS agnostic and works with Windows, macOS, and virtually all Linux distros.

--- a/org/Summa-Cogni/index.md
+++ b/org/Summa-Cogni/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Summa Cogni
+site: http://www.summacogni.org/
+---
+A company founded and run by Magne Lauritzen. Summa Cogni aims to release useful open source hardware of high quality.


### PR DESCRIPTION
This PR requests PID 2211 for Mathpad, a keypad for students and professionals in STEM. 

Source: https://github.com/Summa-Cogni/Mathpad

The Mathpad is at an advanced stage and will soon be launching on Crowd Supply.