### PR TITLE
Request PID 4A46 for JellyfishOPP

### DIFF
--- a/1209/4A46/index.md
+++ b/1209/4A46/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: JellyfishOPP
+owner: hyperglitch
+license: CERN-OHL-S-2.0
+site: https://hyperglitch.com/jellyfish
+source: https://gitlab.com/hyperglitch/jellyfish
+---
+JellyfishOPP (Open Power Profiler) is an open hardware test & measurement device designed to provide advanced, bidirectional power measurements, power optimizations, and battery profiling/simulation as well as being a programmable power supply.

--- a/org/hyperglitch/index.md
+++ b/org/hyperglitch/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: HYPERGLITCH Ltd
+site: https://hyperglitch.com
+---
+HYPERGLITCH Ltd is a hardware and software R&D company from Croatia, providing development services and creating open hardware and open software solutions.


### PR DESCRIPTION
Request PID:4A46 for JellyfishOPP device.

Device info: https://hyperglitch.com/articles/jellyfish
Source code: https://gitlab.com/hyperglitch/jellyfish

Hardware license: CERN-OHL-S-2.0
Firmware & gateware license: GPLv3
