### PR TITLE
Request PID EC02 for ECmini02 by QuadState

### DIFF
--- a/1209/EC02/index.md
+++ b/1209/EC02/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: ECmini02
+owner: QuadState
+license: MIT, CC BY 4.0
+site: https://github.com/QuadState/ECmini02
+source: https://github.com/QuadState/ECmini02
+---
+A compact 2-key USB macro pad using electrostatic capacitive switches and a CH552 microcontroller.  
+It functions as a USB HID device and supports Volume Up, Volume Down, and Mute.

--- a/org/QuadState/orgindex.md
+++ b/org/QuadState/orgindex.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: QuadState
+site: https://github.com/QuadState
+---
+
+QuadState is a personal developer focused on human-interface devices (HID), particularly custom keyboards, electrostatic capacitive switches, and embedded systems.


### PR DESCRIPTION
This pull request registers a new USB PID (EC02) for ECmini02, a 2-key electrostatic capacitive USB macro pad based on the CH552 microcontroller.

The device functions as a USB HID keyboard with media key support (Volume Up/Down/Mute).  
The project is open source and available at: https://github.com/QuadState/ECmini02

This is my first PID request under the shared VID 0x1209.  
Organization profile included under org/QuadState/.