### PR TITLE
Requesting PID for Bruin Spacecraft Group RAPID-0 Board

### DIFF
--- a/1209/4252/index.md
+++ b/1209/4252/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: RAPID-0
+owner: BruinSpacecraftGroup
+license: MIT
+site: https://github.com/Bruin-Spacecraft-Group/RAPID-0-Software
+source: https://github.com/Bruin-Spacecraft-Group/rapid_stm32h743_breakout
+---
+RAPID-0 is a 3U CubeSat developed by Bruin Spacecraft Group at UCLA. The board includes an STM32H743 running CircuitPython with the purpose of testing functionality for developing CDH, EPS, and ADCS flight boards. 

--- a/1209/4252/index.md
+++ b/1209/4252/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: RAPID-0
 owner: BruinSpacecraftGroup
 license: MIT
-site: https://github.com/Bruin-Spacecraft-Group/RAPID-0-Software
+site: https://bruinspace.com/rapid
 source: https://github.com/Bruin-Spacecraft-Group/rapid_stm32h743_breakout
 ---
-RAPID-0 is a 3U CubeSat developed by Bruin Spacecraft Group at UCLA. The board includes an STM32H743 running CircuitPython with the purpose of testing functionality for developing CDH, EPS, and ADCS flight boards. 
+RAPID-0 is a 3U CubeSat developed by Bruin Spacecraft Group at UCLA. This board includes an STM32H743 running CircuitPython.

--- a/org/BruinSpacecraftGroup/index.md
+++ b/org/BruinSpacecraftGroup/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Bruin Spacecraft Group
+site: https://bruinspace.com/
+---
+Bruin Spacecraft Group was founded with the intent of providing a creative and supportive environment for space mission design and development at UCLA.

--- a/org/BruinSpacecraftGroup/index.md
+++ b/org/BruinSpacecraftGroup/index.md
@@ -3,4 +3,4 @@ layout: org
 title: Bruin Spacecraft Group
 site: https://bruinspace.com/
 ---
-Bruin Spacecraft Group was founded with the intent of providing a creative and supportive environment for space mission design and development at UCLA.
+BruinSpace at UCLA is a student-led organization dedicated to fostering innovation, collaboration, and hands-on experience in the field of aerospace engineering. Through hands-on projects, educational programs, and industry partnerships, BruinSpace is creating an environment where students can grow, lead, and make a tangible impact on the world of space exploration.


### PR DESCRIPTION
Assigns PID 0x4252 to an open-source STM32H743 board developed for the RAPID-0 nanosatellite. Custom PCB design and associated firmware are linked. Both the hardware and software are licensed under the MIT license.