### PR TITLE
Add Tillitis TKEY-USB-V2 PID

### DIFF
--- a/1209/8885/index.md
+++ b/1209/8885/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: TKEY-USB-V2
+owner: Tillitis AB
+license: CERN-OHL-S-2.0, GPLv2
+site: https://www.tillitis.se/products/
+source: https://github.com/tillitis/tk1-pcba, https://github.com/tillitis/tillitis-key1
+---
+Version 2 of the USB controller used in the Tillitis Tkey. The TKey is a flexible USB security token.


### PR DESCRIPTION
Hello,

We would like to request VID:PID 1209:8885 for the updated USB controller we
are using in our next Tkey release. The Tkey is an open source
hardware/software flexible USB security token.

Firmware development of the new release is ongoing in the main branch of
https://github.com/tillitis/tillitis-key1. The hardware design is available at
https://github.com/tillitis/tk1-pcba.

Thanks