### PR TITLE
Add PID "EC1A" for EclairM0

### DIFF
--- a/1209/EC1A/index.md
+++ b/1209/EC1A/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: EclairM0
+owner: mateusznowakdev
+license: CERN-OHL-W v2, MIT
+site: https://mateusznowak.dev/eclair
+source: https://github.com/mateusznowakdev/eclair
+---
+
+Small, thin, lightweight notepad device, with PC data sync and other USB HID capabilities. Featuring a tiny display, 14 tactile keys, rechargeable battery, and apps written in TinyGo. Powered by an underclocked SAMD21E18A microcontroller.

--- a/org/mateusznowakdev/index.md
+++ b/org/mateusznowakdev/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Mateusz Nowak
+site: https://mateusznowak.dev
+---
+
+Software engineer, tinkering with electronics in his free time.


### PR DESCRIPTION
Hello,

this PR adds a new organization for me, and there's also a new PID for my first fully custom device:

- https://mateusznowak.dev/eclair (project description)
- https://github.com/mateusznowakdev/eclair (licensed CERN-OHL-W v2, MIT)