### PR TITLE
Request pid 7410 for tf_mux

### DIFF
--- a/1209/7410/index.md
+++ b/1209/7410/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: TF Mux
+owner: wcysite
+license: CERN-OHL-SR-2.0 (hardware), AGPL-3.0
+site: https://github.com/wychlw/TF_MUX/
+source: https://github.com/wychlw/TF_MUX/
+---
+A mux supporting switch a TF card between a reader and a physical port. Useful when you want to remotely control a device and its storage.

--- a/org/wcysite/index.md
+++ b/org/wcysite/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: wcysite
+site: https://wcysite.com/
+---
+An individual enthusiast in CS and EE.


### PR DESCRIPTION
Requesting a PID for tf mux, an open source hardware/software for muxing tf card between a reader and a physical port. A UART is also placed on it for connecting any external device.
PCB using LCEDA, which can be opened by kicad easily if not using this eda; software is under C, using platform io as framework.
Hardware is CERN-OHL-SR-2.0, other is under AGPL-3.0