### PR TITLE
Adding swaziloo/cinque

### DIFF
--- a/1209/6369/index.md
+++ b/1209/6369/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: cinque
+owner: swaziloo
+license: MIT
+site: https://github.com/swaziloo/cinque
+source: https://github.com/swaziloo/cinque
+---
+cinque is a compact columnar staggered split low-profile mechanical keyboard employing QMK or ZMK firmware on RP2040 or NRF52840 controllers.

--- a/org/swaziloo/index.md
+++ b/org/swaziloo/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: swaziloo
+site: https://github.com/swaziloo
+---
+The Esoteric Order of Mechanical Switches, Improvised Engineering, and Extraneous Distractions.


### PR DESCRIPTION
Requesting PID 6369 ("ci") for the open source keyboard project "cinque" available at https://github.com/swaziloo/cinque