### PR TITLE
add skji, skji/coquette (1209/FE80)

### DIFF
--- a/1209/FE80/index.md
+++ b/1209/FE80/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: coquette
+owner: skji
+license: EUPL-1.2
+site: https://thei.rs/coquette
+source: https://thei.rs/coquette
+---
+lovingly over-engineered keyboard (column-stagger, mono-block, split, 42-key) designed to run ZMK with inspiration from: [hummingbird](https://github.com/PJE66/hummingbird), [ruby-choccy](https://thei.rs/rchoc)

--- a/org/skji/index.md
+++ b/org/skji/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: skji
+---
+skji is a cozy community with enough lovely nerds in it to constitute a virtual hackspace


### PR DESCRIPTION
Hiya!
This is a PID request for coquette, a keyboard @galaxyeden and I have been working on for the past 7 months (and have been daily-driving for about half of that time!)

It's a labor of love with many incremental improvements and learnings we along the way, that's finally at a point we consider release-ready.

The keyboard is split into board and shield, and we have multiple versions of each based on design preferences, hand measurements, etc.
All boards and shields under the [coquette org](https://thei.rs/coquette) were made from scratch in (mostly) KiCad.

All original creations are licensed under EUPL-1.2, and derivative works under their parent license (MIT, Apache2).

So this doesn't become a novel, the remaining facts & features as bullet points:
- hours of anatomy (human, bird) & ergonomics research
- different shield angles based on hand measurements
- BLE using nRF5340 (instead of the way more common rRF52840 – gets us some better bluetooth perf)
- ridiculous power optimization (2+ months of daily use, depending on battery size)
- LED underglow on board & shield (literally glows because we're using UV LEDs against neon acrylic)
- very pretty PCBs