### PR TITLE
Request PID F800 for MachiKania Gamepad

### DIFF
--- a/1209/F800/index.md
+++ b/1209/F800/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MachiKania Gamepad
+owner: MachiKania
+license: MIT
+site: https://github.com/kmorimatsu/machikania_gamepad
+source: https://github.com/kmorimatsu/machikania_gamepad
+---
+Simple USB gamepad for MachiKania


### PR DESCRIPTION
I would like to request a PID (0xF800) to use for the gamepad connected by USB to tiny computer system, MachiKania (https://github.com/machikania/phyllosoma).