### PR TITLE
add Ai-On-The-Edge-Cam

### DIFF
--- a/1209/DABB/index.md
+++ b/1209/DABB/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Ai-On-The-Edge-Cam
+owner: prokyber
+license: CERN-OHL-P
+site: https://github.com/prokyber/ai-on-the-edge-cam-hw-description
+source: https://github.com/prokyber/ai-on-the-edge-cam-hw-description
+---
+Ai-On-The-Edge-Cam is an ESP32-S3 board with Ethernet, PoE, SD card, camera, and a Stemma QT connector, compatible with the Ai-On-The-Edge-Device firmware for analog display reading at the edge.

--- a/org/prokyber/index.md
+++ b/org/prokyber/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Prokyber
+site: https://www.tindie.com/stores/allexok/
+---
+Prokyber is a hobby open-source electronics manufacturer. We make products like Esp32 Ethernet boards, nixie/VFD retro displays, and CH32 boards.


### PR DESCRIPTION
Ai-On-The-Edge-Cam is an ESP32-S3 board with Ethernet, PoE, SD card, camera, and a Stemma QT connector, compatible with the Ai-On-The-Edge-Device firmware for analog display reading at the edge.