### PR TITLE
helabs - Keystream PID Request

### DIFF
--- a/1209/8088/index.md
+++ b/1209/8088/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Keystream
+owner: helabs
+license: Apache 2.0
+site: https://github.com/henryhcheung1/keystream
+source: https://github.com/henryhcheung1/keystream
+---
+Keystream is a tiny USB device that prevents your computer from going idle by simulating keyboard activity. The firmware is written in Circuit Python and targets the Raspberry Pi RP2040 microcontroller.

--- a/org/helabs/index.md
+++ b/org/helabs/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: helabs
+site: https://github.com/henryhcheung1
+---
+I am a open source software / hardware enthusiast


### PR DESCRIPTION
Request for a PID for Keystream, a RP2040 based keyboard event sender, from the helabs org. Thank you