### PR TITLE
added alukovenko org for Dendy compatible USB HID controller

### DIFF
--- a/1209/8B17/index.md
+++ b/1209/8B17/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Dendy-compatible Joystick USB HID Interface
+owner: alukovenko
+license: MIT
+site: https://github.com/alukovenko/Dendy_Joystick_USB
+source: https://github.com/alukovenko/Dendy_Joystick_USB
+---
+
+USB HID interface for Dendy (NES Famiclone) controller emulation. This project transforms a classic Dendy/Famicom gamepad into a modern USB HID device using an STM32 BluePill board. Features include support for all standard buttons (D-pad, A/B, Start/Select) plus Turbo A/B functionality with 15Hz rapid fire capability. Perfect for retro gaming enthusiasts who want to use authentic hardware with modern emulators and systems.

--- a/org/alukovenko/index.md
+++ b/org/alukovenko/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: Andrei Lukovenko
+site: https://helpso.me/
+---
+
+Engineer by trade and soul. Infrastructure automation, embedded systems, network protocols, Linux systems and automation.
+
+Building distributed systems, bare-metal deployments, and precision timing protocols. From hardware to large-scale network infrastructure - crafting solutions where hardware meets software since 1990s.


### PR DESCRIPTION
Bluepill-based device that converts NES Famiclone type controller with serial DB-9 interface into a USB HID