### PR TITLE
Request PID 5020 for a virtual input service

### DIFF
--- a/1209/5020/index.md
+++ b/1209/5020/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: vuinputd
+owner: joleuger
+license: MIT
+site: https://github.com/joleuger/vuinputd
+source: https://github.com/joleuger/vuinputd
+---
+
+A user-space service for forwarding virtual input devices from containers to the host on Linux via uinput and CUSE.

--- a/org/joleuger/index.md
+++ b/org/joleuger/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: joleuger
+site: https://github.com/joleuger/
+---
+
+Software architect, and open-source enthusiast interested in low-level Linux systems in my free time.


### PR DESCRIPTION
This PID is requested for a user-space service for forwarding virtual input devices from containers to the host on Linux. The assigned PID will allow consistent device identification of virtual devices created inside containers. Because also virtual devices need a product and vendor id, I want to have a real one to not interfere with real hardware See https://github.com/joleuger/vuinputd/blob/main/README.md and https://kernel.org/doc/html/v4.12/input/uinput.html