### PR TITLE
register 1209/53A0 for the "Diskomator" by Lukas Rieger

### DIFF
--- a/1209/53A0/index.md
+++ b/1209/53A0/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Diskomator 9000 Pro Max
+owner: "0x53A"
+license: MIT
+site: https://0x53a.github.io/esp32-partylight/
+source: https://github.com/0x53A/esp32-partylight
+---
+An ESP32 based Neopixel controller with a microphone, to blink a Pixelmatrix to the beat.
+
+For the time being, this uses an ESP32-S3 DevKit and a I2S microphone (ICS43434) breakout-board, so no custom hardware is required.

--- a/org/0x53A/index.md
+++ b/org/0x53A/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: "0x53A (Lukas Rieger)"
+site: https://github.com/0x53A
+---
+Hi, I'm currently studying mechatronics in Frankfurt.


### PR DESCRIPTION
At the moment this is firmware only with off-the-shelf hardware:

* a ESP32-S3 devboard
* a I2S microphone
* a 16x16 Neopixel Matrix, I use one from amazon

<img src="https://github.com/user-attachments/assets/6aba7667-e129-49f2-a041-0d66543ed430" width="120">

This just runs a FFT on the audio and then maps the FFT channels to different patterns.

Configuration can be changed through Bluetooth, and it can act as a USB "Speaker" so it doesn't use the I2S microphone but instead takes audio data through USB. I'd like to also implement USB Microphone, where it pushes the I2S mic recording to  the Host, and firmware updates.