### PR TITLE
Add PID 5389 for Generic USB HID Controller

### DIFF
--- a/1209/5389/index.md
+++ b/1209/5389/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: Generic USB HID Controller
+owner: infinite-usb-test
+license: MIT
+site: https://github.com/CDiOS/Infinite_USB_Test
+source: https://github.com/CDiOS/Infinite_USB_Test
+---
+Non-commercial, open-source USB HID controller used solely for evaluating
+USB input integration across a variety of simulation and interactive
+software platforms.

--- a/org/infinite-usb-test/index.md
+++ b/org/infinite-usb-test/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Infinite USB Test
+site: https://github.com/CDiOS/Infinite_USB_Test
+---
+Non-commercial open-source USB HID test hardware for development and
+compatibility validation across simulation and interactive platforms.


### PR DESCRIPTION
This pull request adds a PID assignment for a,
open-source USB HID controller.

Organization: Infinite USB Test
Product: Generic USB HID Controller
VID: 0x1209
PID: 0x5389

Source repository:
https://github.com/CDiOS/Infinite_USB_Test
