### PR TITLE
Add 0xB008 and 0xB009 for NU Synths MIDICTRL

### DIFF
--- a/1209/B008/index.md
+++ b/1209/B008/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MIDICTRL
+owner: NUSynths
+license: MIT
+site: https://github.com/noelvissers/nusynths-midictrl
+source: https://github.com/noelvissers/nusynths-midictrl
+---
+Firmware for the NU Synths 'MIDICTRL' eurorack module. Converts MIDI signals (5 pin MIDI or MIDI-USB) to eurorack compatible control voltage (CV) and gate signals.

--- a/1209/B009/index.md
+++ b/1209/B009/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: MIDICTRL Bootloader
+owner: NUSynths
+license: MIT
+site: https://github.com/noelvissers/nusynths-midictrl
+source: https://github.com/noelvissers/nusynths-midictrl
+---
+Bootloader for the NU Synths 'MIDICTRL' eurorack module. Converts MIDI signals (5 pin MIDI or MIDI-USB) to eurorack compatible control voltage (CV) and gate signals.

--- a/org/NUSynths/index.md
+++ b/org/NUSynths/index.md
@@ -1,0 +1,5 @@
+---
+layout: org
+title: NU Synths
+---
+Making synthesizers and other music related hardware/software.


### PR DESCRIPTION
Added 'NU Synths MIDICTRL' to 0xB008.
Added 'NU Synths MIDICTRL Bootloader' to 0xB009.

Firmware under MIT license, hardware under CERN‑OHL‑S v2.0.
https://github.com/noelvissers/nusynths-midictrl 