### PR TITLE
TinyCircuits Thumby & Thumby Color

### DIFF
--- a/1209/3500/index.md
+++ b/1209/3500/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Thumby
+owner: TinyCircuits
+license: MIT
+site: https://tinycircuits.com/products/thumby
+source: https://github.com/TinyCircuits/ASM4008-TinyCircuits-Thumby
+---
+The tiny playable, programmable keychain

--- a/1209/3500/index.md
+++ b/1209/3500/index.md
@@ -4,6 +4,9 @@ title: Thumby
 owner: TinyCircuits
 license: MIT
 site: https://tinycircuits.com/products/thumby
-source: https://github.com/TinyCircuits/ASM4008-TinyCircuits-Thumby
+source: https://github.com/relic-se/circuitpython,https://github.com/TinyCircuits/ASM4008-TinyCircuits-Thumby
 ---
 The tiny playable, programmable keychain
+
+Download the latest CircuitPython firmware for this device:
+https://circuitpython.org/board/tinycircuits_thumby/

--- a/1209/3501/index.md
+++ b/1209/3501/index.md
@@ -4,6 +4,9 @@ title: Thumby Color
 owner: TinyCircuits
 license: MIT
 site: https://tinycircuits.com/products/thumby-color
-source: https://color.thumby.us/
+source: https://github.com/relic-se/circuitpython,https://color.thumby.us/
 ---
 Next generation of the playable, programmable keychain
+
+Download the latest CircuitPython firmware for this device:
+https://circuitpython.org/board/tinycircuits_thumby_color/

--- a/1209/3501/index.md
+++ b/1209/3501/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Thumby Color
+owner: TinyCircuits
+license: MIT
+site: https://tinycircuits.com/products/thumby-color
+source: https://color.thumby.us/
+---
+Next generation of the playable, programmable keychain

--- a/org/TinyCircuits/index.md
+++ b/org/TinyCircuits/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: TinyCircuits
+site: https://tinycircuits.com/
+---
+TinyCircuits designs and manufactures cool electronic miniature products in the US


### PR DESCRIPTION
This update adds the organization, [TinyCircuits](https://tinycircuits.com/), with 2 of their devices: [Thumby](https://tinycircuits.com/products/thumby) and [Thumby Color](https://tinycircuits.com/products/thumby-color). These PIDs are being requested in order to add CircuitPython support to those platforms (see relevant PR: https://github.com/adafruit/circuitpython/pull/10303).