### PR TITLE
Add org entry for Independent Developer and PID allocation for Generic USB CDC-ACM device

### DIFF
--- a/1209/25F0/index.md
+++ b/1209/25F0/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: Generic USB CDC-ACM Device
-owner: Independent Developer
+owner: blue-wind-25
 license: LGPL-3.0-or-later
 site: https://sourceforge.net/projects/jxmake/
 source: https://sourceforge.net/projects/jxmake/

--- a/1209/25F0/index.md
+++ b/1209/25F0/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: Generic USB CDC-ACM Device
+title: JxMake USB CDC-ACM Device
 owner: blue-wind-25
 license: LGPL-3.0-or-later
 site: https://sourceforge.net/projects/jxmake/

--- a/1209/25F0/index.md
+++ b/1209/25F0/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Generic USB CDC-ACM Device
+owner: Independent Developer
+license: LGPL-3.0-or-later
+site: https://sourceforge.net/projects/jxmake/
+source: https://sourceforge.net/projects/jxmake/
+---
+A generic USB CDC-ACM device for non-LUFA-based implementations in the JxMake project, 
+providing firmware and hardware support for USB serial communication across multiple platforms.

--- a/org/blue-wind-25/index.md
+++ b/org/blue-wind-25/index.md
@@ -1,6 +1,6 @@
 ---
 layout: org
-title: Independent Developer
+title: Blue Wind 25
 site: https://sourceforge.net/projects/jxmake/
 ---
 JxMake is a Java‑based, cross‑platform build system inspired by the syntax and features of GNU Make, Perforce Jam, and CMake.

--- a/org/blue-wind-25/index.md
+++ b/org/blue-wind-25/index.md
@@ -1,0 +1,10 @@
+---
+layout: org
+title: Independent Developer
+site: https://sourceforge.net/projects/jxmake/
+---
+JxMake is a Java‑based, cross‑platform build system inspired by the syntax and features of GNU Make, Perforce Jam, and CMake.
+
+In addition, JxMake provides several capabilities not typically found in other console‑based build systems, including a built‑in lightweight GUI, serial console, serial plotter, multi‑MCU in‑system programmer, and more.
+
+It also includes hardware schematics and PCB designs for generic GPIO, MCU programmers, and related tools.


### PR DESCRIPTION
This pull request adds a new organization entry and a device entry under the shared 1209 VID.

Organization:
- Independent Developer
- Site: https://sourceforge.net/projects/jxmake/
- Description: JxMake is a Java‑based, cross‑platform build system inspired by the syntax and features of GNU Make, Perforce Jam, and CMake.
In addition, JxMake provides several capabilities not typically found in other console‑based build systems, including a built‑in lightweight GUI, serial console, serial plotter, multi‑MCU in‑system programmer, and more. It also includes hardware schematics and PCB designs for generic GPIO, MCU programmers, and related tools.


Device:
- Title: Generic USB CDC-ACM Device
- Owner: Independent Developer
- License: LGPL-3.0-or-later
- Source: https://sourceforge.net/projects/jxmake/
- Description: A generic USB CDC-ACM device for non-LUFA-based implementations in the JxMake project, providing firmware and hardware support for USB serial communication across multiple platforms.

This PID allocation will be used for all non-LUFA-based CDC-ACM devices in the JxMake project.
