### PR TITLE
Add Org EngEmil.io and PID EEA1 for AttentioLight-1

### DIFF
--- a/1209/EEA1/index.md
+++ b/1209/EEA1/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: AttentioLight-1
+owner: EngEmil.io
+license: MIT
+site: https://engemil.github.io/attentiolight
+source: https://github.com/engemil/attentiolight-1-firmware
+---
+AttentioLight-1, your personal multi-use RGB light solution in an elegant enclosure. Open-source hardware and software project.

--- a/org/EngEmil.io/index.md
+++ b/org/EngEmil.io/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: EngEmil.io
+site: https://www.engemil.io
+---
+Engineer Emil just doing things.


### PR DESCRIPTION
Add Org EngEmil.io and PID EEA1 for AttentioLight-1.

Site: https://engemil.github.io/attentiolight
Source (firmware): https://github.com/engemil/attentiolight-1-firmware
hardware repo: https://github.com/engemil/attentiolight-1-hardware
