### PR TITLE
added PID 0x200B (VID 0x1209) for hermes by NyxKeys 

### DIFF
--- a/1209/200B/index.md
+++ b/1209/200B/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: Hermes
+owner: nyxkeys
+license: GPL-2.0
+site: https://www.nyxkeys.com
+source: https://github.com/Shiva1796/qmk_firmware/tree/nyxkeys-hermes
+---
+
+NyxKeys Hermes keyboard.

--- a/org/nyxkeys/index.md
+++ b/org/nyxkeys/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: NyxKeys
+site: https://nyxkeys.com
+---
+
+NyxKeys is a Canadian-based keyboard design studio specializing in custom keyboard design.


### PR DESCRIPTION
Registering NyxKeys, a Canadian keyboard design studio, and claiming PID 0x200B (VID 0x1209) for the Hermes keyboard, a QMK-based custom keyboard.