### PR TITLE
Add CoreOrbits Gamerpad VID 1209 PID 2027

### DIFF
--- a/1209/2027/index.md
+++ b/1209/2027/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Gamerpad Virtual HID
+owner: coreorbits
+license: MIT
+site: https://github.com/CoreOrbits/gamerpad-hid-core
+source: https://github.com/CoreOrbits/gamerpad-hid-core
+---
+A virtual USB HID gamepad device for macOS implemented using Apple's CoreHID framework. Enables iOS and Android devices to act as a standard XInput-compatible gamepad controller over a local WiFi connection. The device is entirely virtual — no physical hardware — but implements a complete USB HID interface via Report Descriptor.

--- a/org/coreorbits/index.md
+++ b/org/coreorbits/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: CoreOrbits
+site: https://github.com/CoreOrbits
+---
+CoreOrbits is an independent software development organisation building open source tools and libraries for macOS, iOS, and Android. Projects include virtual HID device implementations, mobile companion apps, and system-level utilities.


### PR DESCRIPTION
New PID request for a virtual USB HID gamepad device 
implemented in software using Apple's CoreHID framework 
on macOS. No physical hardware — implements a complete 
USB HID interface via Report Descriptor.

Source: https://github.com/CoreOrbits/gamerpad-hid-core
License: MIT