### PR TITLE
add VID 1209 PID FDFD and new org FutilityDesigns

### DIFF
--- a/1209/FDFD/index.md
+++ b/1209/FDFD/index.md
@@ -1,0 +1,15 @@
+---
+layout: pid
+title: Continuum Keyboard Firmware
+owner: FutilityDesigns
+license: Firmware - MIT, Hardware - CERN-OHL-W-2.0
+site: http://www.futilitydesigns.com
+source: https://github.com/FutilityDesigns/Continuum-keyboard
+---
+Continuum is a flexible keyboard firmware built on the RP2040 microcontroller. It is designed to run on anything from a 1-key macro pad to a full 110-key keyboard. There is no fixed PCB shape or key count baked into the firmware; you define the layout, wiring, and key assignments through the included visual configuration tool.
+
+The firmware supports plain key assignments, multi-key macros, layer switching, and per-key OLED displays that show what each key does at a glance. Paired with the Active Window Monitor running on your PC, the keyboard can automatically switch its entire layout as you jump between applications — making it a powerful productivity tool, especially for macro pads.
+
+Linked source is for the firmware, which is what the PID gets assigned to. Hardware is in final revisions and links to the hardware repos will be added to the firmware repo as they're finalized.
+
+Official website in progress to be released spring 2026. 

--- a/org/FutilityDesigns/index.md
+++ b/org/FutilityDesigns/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Futility Designs
+site: https://github.com/FutilityDesigns
+---
+Brand for documenting and selling assorted projects - website eventually at www.futilitydesigns.com


### PR DESCRIPTION
Adding new org FutilityDesigns and PID FDFD for Continuum keyboard firmware
RP2040 based keyboard firmware for macropads and custom keyboards. The firmware supports plain key assignments, multi-key macros, layer switching, and per-key OLED displays that show what each key does at a glance. Paired with the Active Window Monitor running on your PC, the keyboard can automatically switch its entire layout as you jump between applications — making it a powerful productivity tool, especially for macro pads.

Hardware documentation in progress, however firmware is designs to run on various hardware and is not locked to one design. Hardware repos will be linked when they're finalized. 

PID is requested for firmware as a way to identify connected devices from the computer side applications. 