### PR TITLE
Requesting PID 0x4D58 under VID 0x1209 for Mixlar Mix

### DIFF
--- a/1209/4D58/index.md
+++ b/1209/4D58/index.md
@@ -1,0 +1,8 @@
+ ---
+  layout: pid
+  title: Mixlar Mix
+  owner: MixlarLabs
+  license: MIT
+  site: https://mixlar.net
+  source: https://github.com/MixlarLabs/MixlarControl
+  ---

--- a/1209/4D58/index.md
+++ b/1209/4D58/index.md
@@ -1,9 +1,9 @@
 ---
 layout: pid
 title: Mixlar Mix
-owner: Mixlarlabs
+owner: MixlarLabs
 license: MIT
-site: http://mixlar.net
+site: https://mixlar.net
 source: https://github.com/MixlarLabs/MixlarControl
 ---
-Mixlar Mix is an open-source hardware that lets users control their pc audio
+USB MIDI controller and audio mixer built on ESP32-S3 with TinyUSB composite device (CDC + MIDI + MSC). Features 4 analog sliders, 6 macro buttons, rotary encoder, and 480x320 touch display.

--- a/1209/4D58/index.md
+++ b/1209/4D58/index.md
@@ -1,8 +1,9 @@
- ---
-  layout: pid
-  title: Mixlar Mix
-  owner: MixlarLabs
-  license: MIT
-  site: https://mixlar.net
-  source: https://github.com/MixlarLabs/MixlarControl
-  ---
+---
+layout: pid
+title: Mixlar Mix
+owner: Mixlarlabs
+license: MIT
+site: http://mixlar.net
+source: https://github.com/MixlarLabs/MixlarControl
+---
+Mixlar Mix is an open-source hardware that lets users control their pc audio

--- a/org/MixlarLabs/index.md
+++ b/org/MixlarLabs/index.md
@@ -1,0 +1,6 @@
+  ---
+  layout: org
+  title: MixlarLabs
+  site: https://mixlar.net
+  ---
+  MixlarLabs builds creative hardware tools for music producers and content creators.


### PR DESCRIPTION
Mixlar Mix is a USB MIDI controller and audio mixer built on ESP32-S3
  using TinyUSB composite device (CDC + MIDI + MSC).

  - Org: MixlarLabs
  - PID: 0x4D58
  - License: MIT
  5. Click Create pull request