### PR TITLE
Add CyberFly Keyboard (PID 0xCF01)

### DIFF
--- a/1209/CF01/index.md
+++ b/1209/CF01/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: CyberFly Keyboard
+owner: eggfly
+license: MIT
+site: https://github.com/eggfly/bufferfly_zmk
+source: https://github.com/eggfly/bufferfly_zmk
+---
+CyberFly is a compact BLE mechanical keyboard powered by an nRF52840 (E73-2G4M08S1C module) running ZMK firmware. It features a 6-row QWERTY layout with PlayStation-style function keys, USB-C connectivity, and a built-in Li-battery.

--- a/1209/CF01/index.md
+++ b/1209/CF01/index.md
@@ -3,7 +3,7 @@ layout: pid
 title: CyberFly Keyboard
 owner: eggfly
 license: MIT
-site: https://github.com/eggfly/bufferfly_zmk
-source: https://github.com/eggfly/bufferfly_zmk
+site: https://github.com/eggfly/cyberfly_zmk
+source: https://github.com/eggfly/cyberfly_zmk
 ---
 CyberFly is a compact BLE mechanical keyboard powered by an nRF52840 (E73-2G4M08S1C module) running ZMK firmware. It features a 6-row QWERTY layout with PlayStation-style function keys, USB-C connectivity, and a built-in Li-battery.

--- a/1209/CF01/index.md
+++ b/1209/CF01/index.md
@@ -6,4 +6,4 @@ license: MIT
 site: https://github.com/eggfly/cyberfly_zmk
 source: https://github.com/eggfly/cyberfly_zmk
 ---
-CyberFly is a compact BLE mechanical keyboard powered by an nRF52840 (E73-2G4M08S1C module) running ZMK firmware. It features a 6-row QWERTY layout with PlayStation-style function keys, USB-C connectivity, and a built-in Li-battery.
+CyberFly is a compact BLE mechanical keyboard powered by an nRF52840 IC running ZMK firmware. It features a 6-row QWERTY layout with PlayStation-style function keys, USB-C connectivity, and a built-in Li-battery.

--- a/org/eggfly/index.md
+++ b/org/eggfly/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: eggfly
+site: https://github.com/eggfly
+---
+An open-source hardware developer focused on custom BLE mechanical keyboards and embedded devices.


### PR DESCRIPTION
## Summary
- Register PID `1209:CF01` for the CyberFly BLE mechanical keyboard
- Add org entry for `eggfly`

## Device Details
- **Name:** CyberFly Keyboard
- **MCU:** nRF52840 IC
- **Firmware:** ZMK (Zephyr-based)
- **Features:** BLE 5.0 + USB-C, compact 6-row QWERTY layout, built-in Li-battery
- **License:** MIT
- **Source:** https://github.com/eggfly/cyberfly_zmk

## Checklist
- [x] Source code is publicly available
- [x] Licensed under a recognized open source license (MIT)
- [x] PID 0xCF01 is currently unassigned
- [x] Org page created at `org/eggfly/index.md`
- [x] PID page created at `1209/CF01/index.md`