### PR TITLE
Request PID block for Infinite HID controller base (electric, hybrid, diesel, steam)

### DIFF
--- a/1209/5390/index.md
+++ b/1209/5390/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Electric Controller Base
+owner: infinite
+license: MIT
+site: https://github.com/CDiOS/infinite-hid-controller-base
+source: https://github.com/CDiOS/infinite-hid-controller-base
+---
+USB HID electric simulation controller base firmware for Arduino Leonardo compatible boards using the Arduino Joystick Library. Provides a simple open reference sketch with one analog axis and example button inputs for further customization.

--- a/1209/5391/index.md
+++ b/1209/5391/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Hybrid Controller Base
+owner: infinite
+license: MIT
+site: https://github.com/CDiOS/infinite-hid-controller-base
+source: https://github.com/CDiOS/infinite-hid-controller-base
+---
+USB HID hybrid simulation controller base firmware for Arduino Leonardo compatible boards using the Arduino Joystick Library. Provides a simple open reference sketch with two analog axes and example button inputs for further customization.

--- a/1209/5392/index.md
+++ b/1209/5392/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Diesel Controller Base
+owner: infinite
+license: MIT
+site: https://github.com/CDiOS/infinite-hid-controller-base
+source: https://github.com/CDiOS/infinite-hid-controller-base
+---
+USB HID diesel simulation controller base firmware for Arduino Leonardo compatible boards using the Arduino Joystick Library. Provides a simple open reference sketch with three analog axes and example button inputs for further customization.

--- a/1209/5393/index.md
+++ b/1209/5393/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Steam Controller Base
+owner: infinite
+license: MIT
+site: https://github.com/CDiOS/infinite-hid-controller-base
+source: https://github.com/CDiOS/infinite-hid-controller-base
+---
+USB HID steam simulation controller base firmware for Arduino Leonardo compatible boards using the Arduino Joystick Library. Provides a simple open reference sketch with four analog axes and example button inputs for further customization.

--- a/org/infinite/index.md
+++ b/org/infinite/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: Infinite
+site: https://github.com/CDiOS/infinite-hid-controller-base
+---
+
+Open-source USB HID controller reference sketches for Arduino Leonardo compatible boards using the Arduino Joystick Library, provided as starting points for electric, hybrid, diesel, and steam simulation control projects.

--- a/org/org/infinite/index.md
+++ b/org/org/infinite/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Infinite
+site: https://github.com/CDiOS/infinite-hid-controller-base
+---
+Open-source USB HID controller reference sketches for Arduino Leonardo compatible boards using the Arduino Joystick Library, provided as starting points for electric, hybrid, diesel, and steam simulation control projects.

--- a/org/org/infinite/index.md
+++ b/org/org/infinite/index.md
@@ -1,6 +1,0 @@
----
-layout: org
-title: Infinite
-site: https://github.com/CDiOS/infinite-hid-controller-base
----
-Open-source USB HID controller reference sketches for Arduino Leonardo compatible boards using the Arduino Joystick Library, provided as starting points for electric, hybrid, diesel, and steam simulation control projects.


### PR DESCRIPTION
Requesting a contiguous block of 4 PIDs for multiple USB HID controller variants based on a shared Arduino Leonardo-compatible platform using the Arduino Joystick Library.

Repository:
https://github.com/CDiOS/infinite-hid-controller-base

Requested assignments:
- 0x5390 Electric Controller Base
- 0x5391 Hybrid Controller Base
- 0x5392 Diesel Controller Base
- 0x5393 Steam Controller Base

These are open reference/base sketches intended as starting points for builders to customize for their own simulation controller hardware.