### PR TITLE
Add Lectrobox org and PIDs 0x71C4 (LectroTIC-4 Timestamper) + 0x71C5 (PG-4 Pulse Generator)

### DIFF
--- a/1209/71C4/index.md
+++ b/1209/71C4/index.md
@@ -1,0 +1,14 @@
+---
+layout: pid
+title: LectroTIC-4 4-Channel Pulse Timestamper
+owner: Lectrobox
+license: GPLv3
+site: https://lectrobox.com/products/timestamper/
+source: https://github.com/jelson/rulos/tree/main/src/app/timestamper
+---
+A four-channel zero-dead-time pulse timestamper with 4-nanosecond
+resolution. Hardware records the moment a pulse arrives on each of
+its four inputs against a 250 MHz counter disciplined to an external
+10 MHz reference clock, and streams the timestamps to the host as
+ASCII over USB CDC. The same USB endpoint accepts SCPI configuration
+commands (slope, divider, stream-enable).

--- a/org/Lectrobox/index.md
+++ b/org/Lectrobox/index.md
@@ -1,0 +1,9 @@
+---
+layout: org
+title: Lectrobox
+site: https://lectrobox.com/
+---
+Lectrobox designs and publishes small open-source electronic
+instruments and gadgets. Hardware schematics, PCB layouts, and
+firmware are released under GPLv3 in the companion RULOS project
+on GitHub: https://github.com/jelson/rulos


### PR DESCRIPTION
Adds a new organization (Lectrobox) and two project PIDs for open-source Lectrobox instruments.

**Org**: Lectrobox — https://lectrobox.com/

**0x71C4 — LectroTIC-4 4-Channel Pulse Timestamper**
- Project page: https://lectrobox.com/products/timestamper/
- Source: https://github.com/jelson/rulos/tree/main/src/app/timestamper (GPLv3)
- Hardware design files: https://github.com/jelson/rulos/tree/main/Schematics/Timestamper
- An STM32H523-based time-interval counter that streams timestamps over USB CDC and accepts SCPI configuration commands on the same endpoint.

**0x71C5 — PG-4 4-Channel Pulse Generator**
- Project page: https://lectrobox.com/products/pulsegen/
- Source: https://github.com/jelson/rulos/tree/main/src/app/pulsegen (GPLv3)
- Hardware design files: https://github.com/jelson/rulos/tree/main/Schematics/PulseGen
- An STM32G474-based 4-channel pulse generator with 250 ps edge placement, four independent channels, SYNC/ASYNC modes and N-cycle bursts, configured with SCPI over USB CDC.