### PR TITLE
D9D0: Finomnis: Busybeacon

### DIFF
--- a/1209/D9D0/index.md
+++ b/1209/D9D0/index.md
@@ -1,0 +1,12 @@
+---
+layout: pid
+title: Busylight
+owner: Finomnis
+license: MIT OR Apache-2.0
+site: https://github.com/Finomnis/busylight
+source: https://github.com/Finomnis/busylight
+---
+An indicator light that shows coworkers if you are busy.
+Intended to be mounted to your monitor and updated whenever your current state changes.
+
+Written in Rust for a custom STM32U0 based PCB.

--- a/org/Finomnis/index.md
+++ b/org/Finomnis/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Martin Stumpf
+site: https://github.com/Finomnis
+---
+I design and publish open source hardware and software, mostly for the Rust community.


### PR DESCRIPTION
Requires a custom VID because it is controllable via USB-HID. So we need a PID:VID to distinguish it from other devices.

Software: https://github.com/Finomnis/busybeacon
Hardware: https://oshwlab.com/finomnis/busylight