### PR TITLE
Neubras - OpenReader Config Standard (ORCS)

### DIFF
--- a/1209/CADA/index.md
+++ b/1209/CADA/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: OpenReader Config Standard (ORCS)
+owner: Neubras
+license: ORCS Attribution License 1.0
+site: http://neubras.com/open-projects/orcs
+source: https://github.com/neubras-br/OpenReader-Config-Standard-ORCS
+---
+OpenReader Config Standard (ORCS) is an open source specification for standardizing the configuration mode of RFID/NFC proximity card readers.
+
+The goal of this project is to make reader configuration interoperable across different software, systems, manufacturers, and devices.
+
+ORCS does not define a specific hardware design, electronic circuit, firmware architecture, or physical reader model. Instead, it defines a common configuration mode that compatible readers can implement so that any software can detect, configure, and manage them in a predictable way.

--- a/org/Neubras/index.md
+++ b/org/Neubras/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Neurbras - OpenReader Config Standard (ORCS)
+site: https://github.com/neubras-br/OpenReader-Config-Standard-ORCS
+---
+Proposed open-source Neubras standard for interoperable configuration of USB RFID/Bio readers. Defines parameters such as output format, byte length, byte order, Wiegand, HEX/decimal, VID/PID and HID/serial/keyboard modes, allowing any software to configure compatible readers in a simple and standardized way.


### PR DESCRIPTION
Neubras - OpenReader Config Standard (ORCS) aims to standardize the configuration of USB card readers. The VID/PID is necessary for the software to identify the device in compatible configuration mode, similar to a bootloader. We will soon add C code examples for STM32FXX and ESP32-S3. We also intend to include basic board layouts so that beginner developers can test reading common cards, such as NFC.
Thanks