### PR TITLE
Add 1209:4665 ferros (Nick Spiker)

### DIFF
--- a/1209/4665/index.md
+++ b/1209/4665/index.md
@@ -1,0 +1,11 @@
+---
+layout: pid
+title: ferros
+owner: nickspiker
+license: Apache-2.0
+site: https://github.com/nickspiker/ferros
+source: https://github.com/nickspiker/ferros
+---
+ferros is an open-source mobile operating system written from first principles in Rust, built on the Redox microkernel. This PID identifies a USB device running ferros for peer-to-peer connectivity between ferros systems.
+
+The PID `0x4665` is the ASCII encoding of "Fe" — both the chemical symbol for iron (the etymological root of the project name) and a human-readable identifier visible in USB descriptor hex dumps.

--- a/org/nickspiker/index.md
+++ b/org/nickspiker/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Nick Spiker
+site: https://github.com/nickspiker
+---
+Independent developer working on ferros, an open-source mobile operating system written from first principles in Rust, and related open hardware projects.


### PR DESCRIPTION
Adds:

- `org/nickspiker/` — organization page
- `1209/4665/` — ferros (open-source mobile OS in Rust)

[ferros](https://github.com/nickspiker/ferros) is licensed under Apache-2.0, with the LICENSE file in the source repository.

PID `0x4665` is the ASCII encoding of "Fe" — the chemical symbol for iron, etymological root of the project name, and a human-readable identifier in USB descriptor hex dumps.