### PR TITLE
Add 1209/9210 Mimic X + 1209/9211 Mimic X Bridge (kunichiko)

### DIFF
--- a/1209/9210/index.md
+++ b/1209/9210/index.md
@@ -1,0 +1,13 @@
+---
+layout: pid
+title: Mimic X
+owner: kunichiko
+license: MIT
+site: https://github.com/kunichiko/MimicX-firmware
+source: https://github.com/kunichiko/MimicX-firmware
+---
+A USB device that receives commands from a smartphone over USB-MIDI and
+emulates retro-PC HID peripherals (ATARI joystick, Sega Mega Drive
+6-button pad, Sharp X68000 keyboard and mouse). Built around the WCH
+CH32X035 MCU. Firmware is MIT-licensed; PCB designs are published at
+<https://github.com/kunichiko/MimicX-hardware> (also MIT).

--- a/org/kunichiko/index.md
+++ b/org/kunichiko/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: kunichiko
+site: https://github.com/kunichiko
+---
+Kunihiko Ohnaka. Individual developer building peripherals and hardware
+revival projects for retro computers such as the Sharp X68000.


### PR DESCRIPTION
Requesting PIDs `0x1209:0x9210` for **Mimic X** and `0x1209:0x9211` for **Mimic X Bridge**.

- **Mimic X (0x9210)**: USB-MIDI receiver that emulates retro-PC HID peripherals (ATARI joystick, Sega Mega Drive 6-button pad, Sharp X68000 keyboard and mouse) for retro computers, driven from a smartphone over USB-MIDI. Built around the WCH CH32X035 MCU.
- **Mimic X Bridge (0x9211)**: wireless/wired bridge variant — an ESP32 module (C6 / S3 / C3) exposes a USB-MIDI device (TinyUSB) and a BLE-MIDI peripheral simultaneously, and relays MIDI/SysEx to the CH32X035-based device engine over I2C.
- **Firmware repo (Apache-2.0)**: https://github.com/kunichiko/MimicX-firmware
- **Hardware repo (CERN-OHL-S-2.0)**: https://github.com/kunichiko/MimicX-hardware
- Both repos have LICENSE files and contain modifiable sources (firmware code, and the board designs as atopile source plus KiCad layouts).
- This is the organisation's first PIDs and registers a new `kunichiko` org page.

**Licensing note.** This PR originally said MIT for both repos. Since then I moved the project off a blanket MIT: MIT is a software licence and doesn't map onto board designs, so the hardware repo is now **CERN-OHL-S-2.0** and the firmware and app are **Apache-2.0** (the protocol spec is CC BY 4.0). The `license:` field in both PID entries has been updated to match. The vendor-supplied symbols, footprints and 3D models under `parts/` are third-party and are carved out in [`NOTICE`](https://github.com/kunichiko/MimicX-hardware/blob/main/NOTICE); datasheet PDFs are no longer redistributed and are linked from each board's `parts/README.md` instead.
