### PR TITLE
Add 1209/8500 SteFly Stick Remote

### DIFF
--- a/1209/8500/index.md
+++ b/1209/8500/index.md
@@ -1,0 +1,31 @@
+---
+layout: pid
+title: SteFly Stick Remote
+owner: SteFly.aero
+license: MIT (firmware)
+site: https://stefly.aero/
+source: https://github.com/OpenSoaring/StickRemote-SteFly/
+
+hidden: false
+---
+
+# {{ page.title }}
+
+* Manufacturer: SteFly
+* Project URL: <https://github.com/OpenSoaring/StickRemote-SteFly>
+* License: MIT (firmware)
+
+USB-HID keyboard / mouse remote stick for sailplane navigation computers
+running [OpenSoar](https://github.com/OpenSoaring/OpenSoar),
+[XCSoar](https://xcsoar.org/) or [OpenVario](https://www.openvario.org/).
+Built around an Arduino Leonardo (ATmega32U4), mounted on the control stick
+of gliders.
+
+Buttons and a thumb-joystick are translated into keystrokes (function keys,
+arrow keys, Escape, Return) and mouse movements that the navigation
+software interprets as menu / map / pilot-event commands. Long-press
+gestures are mapped to additional commands such as Quit, Shutdown or
+PilotEvent.
+
+Firmware source code and hardware layout: see the project URL above.
+Product information: <https://www.stefly.aero/product/stefly-leather-remote-stick>

--- a/1209/8501/index.md
+++ b/1209/8501/index.md
@@ -1,0 +1,31 @@
+---
+layout: pid
+title: SteFly Stick Bootloader
+owner: SteFly.aero
+license: MIT (firmware)
+site: https://stefly.aero/
+source: https://github.com/OpenSoaring/StickRemote-SteFly/
+
+hidden: false
+---
+
+# {{ page.title }}
+
+* Manufacturer: SteFly
+* Project URL: <https://github.com/OpenSoaring/StickRemote-SteFly>
+* License: MIT (firmware)
+
+USB-HID keyboard / mouse remote stick for sailplane navigation computers
+running [OpenSoar](https://github.com/OpenSoaring/OpenSoar),
+[XCSoar](https://xcsoar.org/) or [OpenVario](https://www.openvario.org/).
+Built around an Arduino Leonardo (ATmega32U4), mounted on the control stick
+of gliders.
+
+Buttons and a thumb-joystick are translated into keystrokes (function keys,
+arrow keys, Escape, Return) and mouse movements that the navigation
+software interprets as menu / map / pilot-event commands. Long-press
+gestures are mapped to additional commands such as Quit, Shutdown or
+PilotEvent.
+
+Firmware source code and hardware layout: see the project URL above.
+Product information: <https://www.stefly.aero/product/stefly-leather-remote-stick>

--- a/org/SteFly.aero/index.md
+++ b/org/SteFly.aero/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: SteFly
+---
+
+# {{ page.title }}
+
+SteFly is a manufacturer of avionics and cockpit accessories for sailplane
+and motor glider pilots, based in Germany. Products include cockpit
+instrumentation, control sticks, and pilot input devices used with open-source
+flight computers such as OpenSoar, XCSoar and OpenVario.
+
+The firmware for SteFly's USB HID devices is developed in collaboration with
+the OpenSoaring open-source community and released under the MIT license.
+
+* Website: <https://www.stefly.aero>
+* Firmware repository: <https://github.com/OpenSoaring/Stick_Remote_Control_SteFly>


### PR DESCRIPTION
Open-source firmware (MIT) for a HID keyboard/mouse remote stick used in soaring navigation systems. Hardware is commercial.