### PR TITLE
PID B011 for gblink adapter

### DIFF
--- a/1209/B011/index.md
+++ b/1209/B011/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Game Boy Link Adapter
+owner: starlarkus
+license: GPL-3.0
+site: https://gblink.io
+source: https://github.com/starlarkus/GBLink-Firmware
+---
+GBLink USB connects a Game Boy to a computer for online connectivity and custom utilities. Play Game Boy games online using original hardware.

--- a/org/starlarkus/index.md
+++ b/org/starlarkus/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: starlarkus
+site: https://github.com/starlarkus
+---
+I am an open source developer focused on custom hardware and software to connect original Game Boy hardware to the internet.


### PR DESCRIPTION
Requesting PID B011 for Game boy link adapter to connect gameboy games online with original hardware.

Firmware source code GPL3: https://github.com/starlarkus/GBLink-Firmware

PCB source MIT: https://github.com/weimanc/game-boy-zero-link-board