### PR TITLE
Add PID 0xC035: CH32X035 USB Power Meter

### DIFF
--- a/1209/C035/index.md
+++ b/1209/C035/index.md
@@ -6,4 +6,12 @@ license: Apache-2.0
 site: https://github.com/krzysztofgawrys/ch32x035-usb-power-meter
 source: https://github.com/krzysztofgawrys/ch32x035-usb-power-meter
 ---
-USB power meter with INA228 20-bit sensor, ST7789 color TFT display and CDC data logging shell, based on WCH CH32X035 (RISC-V).
+USB power meter built around the WCH CH32X035 RISC-V microcontroller.
+
+Hardware: INA228 20-bit power/energy monitor (up to 85 V, 10 mOhm shunt),
+ST7789 240x135 color TFT display, USB-C connector for Full-Speed USB.
+
+Firmware: bare-metal C, USB CDC virtual serial port with an interactive
+data logging shell (live streaming, averaging, calibration, mAh/mWh
+accumulator, min/max tracking). Supports USB DFU 1.1 firmware updates
+via a companion bootloader.

--- a/1209/C035/index.md
+++ b/1209/C035/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: CH32X035 USB Power Meter
+owner: krzysztofgawrys
+license: Apache-2.0
+site: https://github.com/krzysztofgawrys/ch32x035-usb-power-meter
+source: https://github.com/krzysztofgawrys/ch32x035-usb-power-meter
+---
+USB power meter with INA228 20-bit sensor, ST7789 color TFT display and CDC data logging shell, based on WCH CH32X035 (RISC-V).

--- a/org/krzysztofgawrys/index.md
+++ b/org/krzysztofgawrys/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Krzysztof Gawrys
+site: https://github.com/krzysztofgawrys
+---
+Embedded firmware developer. WCH CH32X035 projects.


### PR DESCRIPTION
Requesting PID **0xC035** for the CH32X035 USB Power Meter project.

- **VID:PID** 1209:C035
- **License:** Apache-2.0
- **Source:** https://github.com/krzysztofgawrys/ch32x035-usb-power-meter
- **Description:** USB power meter with INA228 20-bit sensor, ST7789 color TFT display and CDC data logging shell, based on WCH CH32X035 (RISC-V).