### PR TITLE
Add Zolex Labs Ltd org + 1209:8800 Zolex Superboard

### DIFF
--- a/1209/8800/index.md
+++ b/1209/8800/index.md
@@ -7,3 +7,8 @@ site: https://zolex.co/sb
 source: https://github.com/zolexlabs/superboard
 ---
 Zolex Superboard -- RP2040 dev board with a built-in logic analyser, CMSIS-DAP probe and 25-LED dashboard.
+
+Hardware (schematic, PCB, BOM) is CERN-OHL-S-2.0. The logic analyser is MIT throughout -- wire protocol
+and device firmware at <https://github.com/zolexlabs/superboard/tree/main/firmware>, host implementation
+at <https://github.com/zolexlabs/superboard/tree/main/software/superboard-la>. The debug interface is
+CMSIS-DAP, so pyOCD and OpenOCD drive it unmodified.

--- a/1209/8800/index.md
+++ b/1209/8800/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Zolex Superboard
+owner: zolex
+license: CERN-OHL-S-2.0
+site: https://zolex.co/sb
+source: https://github.com/zolexlabs/superboard
+---
+Zolex Superboard -- RP2040 dev board with a built-in logic analyser, CMSIS-DAP probe and 25-LED dashboard.

--- a/org/zolex/index.md
+++ b/org/zolex/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Zolex Labs Ltd
+site: https://zolex.co/
+---
+Open hardware for embedded development -- maker of the Zolex Superboard.


### PR DESCRIPTION
Requesting PID 1209:8800 for the Zolex Superboard — open-source hardware. Design files (schematic, PCB, BOM) are public under
  CERN-OHL-S-2.0 at https://github.com/zolexlabs/superboard. This PR adds the Zolex Labs Ltd org page and the 8800 entry.

Thanks!
Andy