### PR TITLE
Add GregoryGHamilton and PID 201A for CW USB Adapter

### DIFF
--- a/1209/201A/index.md
+++ b/1209/201A/index.md
@@ -1,0 +1,14 @@
+---
+layout: pid
+title: CW USB Adapter
+owner: GregoryGHamilton
+license: CC BY-SA 3.0, MIT
+site: https://github.com/ve7ggh/CW-USB-Adapter-1.1
+source: https://github.com/ve7ggh/CW-USB-Adapter-1.1
+---
+The VE7GGH CW USB Adapter is an open-source USB interface for Morse-code
+paddles and straight keys. It enumerates as a USB HID keyboard and is based
+on an ATSAMD21E18A microcontroller.
+
+Hardware design files are licensed under CC BY-SA 3.0 Unported and firmware
+is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 [![Build Status](https://travis-ci.org/pidcodes/pidcodes.github.com.svg?branch=master)](https://travis-ci.org/pidcodes/pidcodes.github.com)
 
 Website for [pid.codes](http://pid.codes)
+

--- a/org/GregoryGHamilton/index.md
+++ b/org/GregoryGHamilton/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: GregoryGHamilton
+site: https://github.com/ve7ggh
+---
+Canadian electronics and HAM radio enthusiast .

--- a/org/GregoryGHamilton/index.md
+++ b/org/GregoryGHamilton/index.md
@@ -3,4 +3,4 @@ layout: org
 title: GregoryGHamilton
 site: https://github.com/ve7ggh
 ---
-Canadian electronics and HAM radio enthusiast .
+Canadian electronics and HAM radio enthusiast.

--- a/org/GregoryGHamilton/index.md
+++ b/org/GregoryGHamilton/index.md
@@ -3,4 +3,4 @@ layout: org
 title: GregoryGHamilton
 site: https://github.com/ve7ggh
 ---
-Canadian electronics and HAM radio enthusiast.
+Canadian open-source electronics and HAM radio enthusiast.


### PR DESCRIPTION
Requesting PID `0x201A` under VID `0x1209` for the CW USB Adapter.

The CW USB Adapter is an open-source USB HID keyboard interface for Morse-code
paddles and straight keys, based on the ATSAMD21E18A microcontroller.

Source, firmware, PCB design files, manufacturing files, and license information:
https://github.com/ve7ggh/CW-USB-Adapter-1.1