### PR TITLE
Request PID code 2027 for twist4 project

### DIFF
--- a/1209/2027/index.md
+++ b/1209/2027/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: twist4
+owner: rppicomidi
+license: MIT
+site: https://rppicomidi.github.io
+source: https://github.com/rppicomidi/twist4
+---
+A Raspberry Pi Pico-based 4 channel USB MIDI controller with encoder and display per channel for use with VCV Rack.

--- a/org/rppicomidi/index.md
+++ b/org/rppicomidi/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: rppicomidi
+site: https://rppicomidi.github.io
+---
+Publish open source hardware, firmware and software Music and MIDI projects that
+primarily target the Raspberry Pi Pico family of processor boards.


### PR DESCRIPTION
I would like to use PID code 2027 for the twist4 project. The twist4 hardware is CC-BY-SA, the firmware is MIT, and the companion Twist plugin is GPLv3. See the project documentation for more information.