### PR TITLE
Add 1209/2012: Positron Electronic 12pad

### DIFF
--- a/1209/2012/index.md
+++ b/1209/2012/index.md
@@ -1,0 +1,10 @@
+---
+layout: pid
+title: 12pad
+owner: Positron Electronic
+license: GPL-2.0
+site: https://github.com/juarendra/12pad-QMK-VIA
+source: https://github.com/juarendra/12pad-QMK-VIA
+---
+12-key hotswap macropad with a rotary encoder, based on the STM32F401
+(WeAct Blackpill), running QMK firmware with VIA support.

--- a/1209/2012/index.md
+++ b/1209/2012/index.md
@@ -1,7 +1,7 @@
 ---
 layout: pid
 title: 12pad
-owner: Positron Electronic
+owner: Positron-Electronic
 license: GPL-2.0
 site: https://github.com/juarendra/12pad-QMK-VIA
 source: https://github.com/juarendra/12pad-QMK-VIA

--- a/org/Positron-Electronic/index.md
+++ b/org/Positron-Electronic/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Positron Electronic
+site: https://github.com/juarendra
+---
+Custom mechanical keyboard and macropad maker from Indonesia.


### PR DESCRIPTION
Requesting PID 0x2012 under VID 0x1209 for the 12pad, an open-source 12-key hotswap macropad with rotary encoder by Positron Electronic.

- MCU: STM32F401 (WeAct Blackpill)
- Firmware: QMK with VIA support, licensed GPL-2.0
- Source/hardware: https://github.com/juarendra/12pad-QMK-VIA

Thanks!