### PR TITLE
Request PID 0x3001 for Custom USB Keyboard and Touchpad

### DIFF
--- a/1209/3001/index.md
+++ b/1209/3001/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Custom USB Touchpad Controller
+owner: keyboard-touchpad-lab
+license: CERN-OHL-P-2.0
+site: https://github.com/paddygather-droid/LKB-119
+source: https://github.com/paddygather-droid/LKB-119
+---
+A high-performance USB keyboard and touchpad device based on STM32 MCU and touch sensor. Features smooth scrolling and multi-touch capabilities.

--- a/org/keyboard-touchpad-lab/index.md
+++ b/org/keyboard-touchpad-lab/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: My Keyboard and Touchpad Lab
+site: https://github.com/your-github-username
+---
+An independent hardware team developing custom open-source USB peripherals and keyboard and touch input devices.


### PR DESCRIPTION
Hello, I would like to request PID 0x3001 under VID 0x1209 for an open-source USB keyboard and touchpad project.

- Organization: paddygather-droid
- Requested PID: 0x3001
- License: CERN-OHL-P-2.0
- Project Source: https://github.com/paddygather-droid/LKB-119

All index.md files have been added. Thank you!