### PR TITLE
Allocate PID 0x7050 for Positron Electronic

### DIFF
--- a/1209/7050/index.md
+++ b/1209/7050/index.md
@@ -1,0 +1,8 @@
+---
+layout: pid
+title: OSUpad
+owner: Positron Electronic
+license: MIT
+repo: https://github.com/juarendra/OSUpad-QMK-VIA
+---
+A 2x3 hotswap and tactile rhythm game macropad by Positron Electronic.

--- a/1209/7050/index.md
+++ b/1209/7050/index.md
@@ -1,4 +1,4 @@
-﻿---
+---
 layout: pid
 title: OSUpad
 owner: Positron-Electronic

--- a/1209/7050/index.md
+++ b/1209/7050/index.md
@@ -1,7 +1,7 @@
----
+﻿---
 layout: pid
 title: OSUpad
-owner: Positron Electronic
+owner: Positron-Electronic
 license: MIT
 repo: https://github.com/juarendra/OSUpad-QMK-VIA
 ---

--- a/org/Positron Electronic.md
+++ b/org/Positron Electronic.md
@@ -1,6 +1,0 @@
----
-layout: org
-title: Positron Electronic
----
-
-Positron Electronic is an open-source hardware creator focusing on custom keypads and macropads.

--- a/org/Positron Electronic.md
+++ b/org/Positron Electronic.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Positron Electronic
+---
+
+Positron Electronic is an open-source hardware creator focusing on custom keypads and macropads.

--- a/org/Positron-Electronic/index.md
+++ b/org/Positron-Electronic/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: Positron Electronic
+repo: https://github.com/juarendra
+---
+Positron Electronic is an open-source hardware creator focusing on custom keypads and macropads.


### PR DESCRIPTION
Allocates an ID under the open-source \