### PR TITLE
Add 1209/FEE1 - ESSOTEC XENPAD One

### DIFF
--- a/1209/FEE1/index.md
+++ b/1209/FEE1/index.md
@@ -8,7 +8,9 @@ source: https://github.com/xenpads/xenpad-firmware
 ---
 A programmable USB button with a full-colour indicator, built on a Waveshare
 RP2040-Zero with a mechanical switch and a WS2812. Firmware uses the Raspberry
-Pi Pico SDK and TinyUSB and is released under the the GNU General Public License v3.
+Pi Pico SDK and TinyUSB and is released under the GNU General Public License
+v3 or later. The wire protocol header and the reference host tools are MIT, so
+that host software talking to the device is not bound by copyleft.
 
 The device exposes two HID interfaces: a keyboard interface, which sends
 shortcuts stored in the device's own flash, and a vendor interface (usage page

--- a/1209/FEE1/index.md
+++ b/1209/FEE1/index.md
@@ -1,0 +1,17 @@
+---
+layout: pid
+title: XENPAD One
+owner: essotec
+license: MIT
+site: https://xenpads.com
+source: https://github.com/xenpads/xenpad-firmware
+---
+A programmable USB button with a full-colour indicator, built on a Waveshare
+RP2040-Zero with a mechanical switch and a WS2812. Firmware uses the Raspberry
+Pi Pico SDK and TinyUSB and is released under the MIT licence.
+
+The device exposes two HID interfaces: a keyboard interface, which sends
+shortcuts stored in the device's own flash, and a vendor interface (usage page
+0xFF00) used by host software to receive gesture events and drive the
+indicator. Routing is configurable per gesture. The firmware is fully usable
+without any host software.

--- a/1209/FEE1/index.md
+++ b/1209/FEE1/index.md
@@ -2,13 +2,13 @@
 layout: pid
 title: XENPAD One
 owner: essotec
-license: MIT
+license: GPL-3.0-or-later
 site: https://xenpads.com
 source: https://github.com/xenpads/xenpad-firmware
 ---
 A programmable USB button with a full-colour indicator, built on a Waveshare
 RP2040-Zero with a mechanical switch and a WS2812. Firmware uses the Raspberry
-Pi Pico SDK and TinyUSB and is released under the MIT licence.
+Pi Pico SDK and TinyUSB and is released under the the GNU General Public License v3.
 
 The device exposes two HID interfaces: a keyboard interface, which sends
 shortcuts stored in the device's own flash, and a vendor interface (usage page

--- a/org/essotec/index.md
+++ b/org/essotec/index.md
@@ -1,0 +1,7 @@
+---
+layout: org
+title: ESSOTEC
+site: https://xenpads.com
+---
+ESSOTEC designs and builds small desktop hardware. XENPAD, its first product
+line, is a programmable USB button with a full-colour indicator.


### PR DESCRIPTION
XENPAD One is a programmable USB button with an RGB indicator, built on a Waveshare RP2040-Zero. Firmware is MIT and public: https://github.com/xenpads/xenpad-firmware

The PID is requested for the device rather than for individual builders because it is a manufactured product sold to end users, and operating systems cache HID descriptors by VID/PID pair - each unit must present the same identifiers.