### PR TITLE
Add OpenVVVF organization and request PID F0C7 for OpenVVVF Control Module

### DIFF
--- a/1209/F0C7/index.md
+++ b/1209/F0C7/index.md
@@ -1,0 +1,9 @@
+---
+layout: pid
+title: Control Module
+owner: OpenVVVF
+license: GPL-3.0 and CERN-OHL-W-2.0
+site: https://docs.openvvvf.org/
+source: https://github.com/OpenVVVF
+---
+An open traction inverter and power conversion platform.

--- a/org/OpenVVVF/index.md
+++ b/org/OpenVVVF/index.md
@@ -1,0 +1,6 @@
+---
+layout: org
+title: OpenVVVF
+site: https://docs.openvvvf.org/
+---
+OpenVVVF is an open-source traction inverter and power conversion platform.


### PR DESCRIPTION
     Requesting PID 1209/F0C7 for the OpenVVVF Control Module.                                                                                        
                                                                                                                                                           
     OpenVVVF is an open-source traction inverter and power conversion platform for 3-phase AC drives and more.                                                     
                                                                                                                                                           
     - Site: https://docs.openvvvf.org/                                                                                                                    
     - Source: https://github.com/OpenVVVF                                                                                                                 
       - Hardware designs: https://github.com/OpenVVVF/Hardware (CERN-OHL-W-2.0)                                                                           
       - Firmware / RTE tools: https://github.com/OpenVVVF/RTE (GPL-3.0)                                                                                   
                                                                                                                                                           
     The requested PID will be used for the USB interface on the OpenVVVF control module.  (See image below of assembled prototype inverter)

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/b2eb0670-5b60-465f-86ba-29a815ed1138" />
